### PR TITLE
Fixed module shebangs to use #!/usr/bin/python

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_shutdown
+++ b/library/junos_shutdown
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_zeroize
+++ b/library/junos_zeroize
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman


### PR DESCRIPTION
Ansible modules should always use "#!/usr/bin/python" or "#!powershell" as their shebang line. You can see this practice with a quick grep of the library directory in Ansible.

```
cowboy:library mhite$ grep -r "#\!" *
cloud/azure:#!/usr/bin/python
cloud/cloudformation:#!/usr/bin/python
cloud/digital_ocean:#!/usr/bin/python
cloud/digital_ocean_domain:#!/usr/bin/python
cloud/digital_ocean_sshkey:#!/usr/bin/python
cloud/docker:#!/usr/bin/python
cloud/docker_image:#!/usr/bin/python
cloud/ec2:#!/usr/bin/python
cloud/ec2_ami:#!/usr/bin/python
cloud/ec2_ami_search:#!/usr/bin/python
cloud/ec2_asg:#!/usr/bin/python
cloud/ec2_eip:#!/usr/bin/python
cloud/ec2_elb:#!/usr/bin/python
cloud/ec2_elb_lb:#!/usr/bin/python
cloud/ec2_facts:#!/usr/bin/python
cloud/ec2_group:#!/usr/bin/python
cloud/ec2_key:#!/usr/bin/python
cloud/ec2_lc:#!/usr/bin/python
cloud/ec2_metric_alarm:#!/usr/bin/python
cloud/ec2_scaling_policy:#!/usr/bin/python
cloud/ec2_snapshot:#!/usr/bin/python
cloud/ec2_tag:#!/usr/bin/python
cloud/ec2_vol:#!/usr/bin/python
cloud/ec2_vpc:#!/usr/bin/python
...
windows/win_feature:#!/usr/bin/python
windows/win_feature.ps1:#!powershell
windows/win_get_url:#!/usr/bin/python
windows/win_get_url.ps1:#!powershell
windows/win_group:#!/usr/bin/python
windows/win_group.ps1:#!powershell
windows/win_msi:#!/usr/bin/python
windows/win_msi.ps1:#!powershell
windows/win_ping:#!/usr/bin/python
windows/win_ping.ps1:#!powershell
windows/win_service:#!/usr/bin/python
windows/win_service.ps1:#!powershell
windows/win_stat:#!/usr/bin/python
windows/win_stat.ps1:#!powershell
windows/win_user:#!/usr/bin/python
windows/win_user.ps1:#!powershell
```

In order for the "ansible_python_interpreter" path substitution to work properly (see http://docs.ansible.com/faq.html#how-do-i-handle-python-pathing-not-having-a-python-2-x-in-usr-bin-python-on-a-remote-machine), using "#!/usr/bin/python" is a requirement. The way the modules are currently published using a shebang of "#!/usr/bin/env python2.7", setting "ansible_python_interpreter" effectively does nothing and substitution fails.

You can see the interpreter substitution behavior in lib/ansible/module_common.py. Look for the modify_module() function in the ModuleReplacer class.
