### PR TITLE
adding 'port' and 'comment' options to applicable junos_* modules

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -82,6 +82,11 @@ options:
               I(console) option.
         required: false
         default: None
+    port:
+        description:
+            - TCP port number to use when connecting to the device
+        required: false
+        default: 830
 '''
 
 EXAMPLES = '''
@@ -117,7 +122,8 @@ def main():
             logfile=dict(required=False, default=None),
             savedir=dict(required=False, default=None),
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None)),
+            passwd=dict(required=False, default=None),
+            port=dict(required=False, default=830))),
         supports_check_mode=False)
 
     m_args = module.params
@@ -131,7 +137,7 @@ def main():
         # -----------
         # via NETCONF
         # -----------
-        dev = Device(m_args['host'], user=m_args['user'], passwd=m_args['passwd'])
+        dev = Device(m_args['host'], user=m_args['user'], passwd=m_args['passwd'], port=m_args['port'])
         try:
             dev.open()
         except Exception as err:

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -326,7 +326,8 @@ def main():
             savedir=dict(required=False),
             timeout=dict(required=False, default=0),
             comment=dict(required=False, default=None),
-            port=dict(required=False, default=830)),
+            port=dict(required=False, default=830)
+        ),
         supports_check_mode=False)
 
     if not HAS_PYEZ:

--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -103,6 +103,11 @@ options:
            for debugging purposes
       required: false
       default: None
+    port:
+        description:
+            - TCP port number to use when connecting to the device
+        required: false
+        default: 830
 '''
 
 EXAMPLES = '''
@@ -215,7 +220,8 @@ def main():
             logfile=dict(required=False, default=None),
             no_copy=dict(required=False, choices=BOOLEANS, default=False),
             reboot=dict(required=False, choices=BOOLEANS, default=True),
-            reboot_pause=dict(required=False, type='int', default=10)
+            reboot_pause=dict(required=False, type='int', default=10),
+            port=dict(required=False, default=830)
         ),
         supports_check_mode=True
     )
@@ -228,7 +234,7 @@ def main():
     # @@@ need to verify that the package file actually exists
     # @@@ before proceeding.
 
-    dev = Device(args['host'], user=args['user'], password=args['passwd'])
+    dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'])
     try:
         dev.open()
     except Exception as err:

--- a/library/junos_shutdown
+++ b/library/junos_shutdown
@@ -71,6 +71,11 @@ options:
             - Safety mechanism. You B(MUST) set this to 'shutdown'.
         required: yes
         default: None
+    port:
+        description:
+            - TCP port number to use when connecting to the device
+        required: false
+        default: 830
 '''
 
 EXAMPLES = '''
@@ -96,7 +101,9 @@ def main():
             host=dict(required=True, default=None),       # host or ipaddr
             user=dict(required=False, default=os.getenv('USER')),
             passwd=dict(required=False, default=None),
-            reboot=dict(required=False, choices=BOOLEANS, default=False)),
+            reboot=dict(required=False, choices=BOOLEANS, default=False),
+            port=dict(required=False, default=830)
+        ),
         supports_check_mode=False)
 
     if not HAS_PYEZ:
@@ -109,7 +116,7 @@ def main():
     restart_mode = module.boolean(args['reboot'])
 
     try:
-        dev = Device(args['host'], user=args['user'], password=args['passwd']).open()
+        dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port']).open()
     except Exception as err:
         msg = 'unable to connect to {0}: {1}'.format(args['host'], str(err))
         module.fail_json(msg=msg)

--- a/library/junos_zeroize
+++ b/library/junos_zeroize
@@ -88,6 +88,11 @@ options:
               for debugging purposes
         required: false
         default: None
+    port:
+        description:
+            - TCP port number to use when connecting to the device
+        required: false
+        default: 830
 notes:
     - You B(MUST) either use the I(host) option or the I(console) option to designate
       how the device is accessed.
@@ -111,7 +116,9 @@ def main():
             console=dict(required=False, default=None),     # param to netconify
             user=dict(required=False, default=os.getenv('USER')),
             passwd=dict(required=False, default=None),
-            logfile=dict(required=False, default=None)),
+            logfile=dict(required=False, default=None)
+            port=dict(required=False, default=830)
+        ),
         supports_check_mode=False)
 
     args = module.params
@@ -146,7 +153,7 @@ def main():
         except ImportError:
             module.fail_json(msg='junos-eznc is required for this module')
 
-        dev = Device(args['host'], user=args['user'], password=args['passwd'])
+        dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'])
         try:
             use_notifier('LOGIN', 'host={0}'.format(args['host']))
             dev.open()


### PR DESCRIPTION
Adds the 'comment' option to the junos_install_config module allowing the user to supply a comment to the commit log if the commit was successful.

Adds the 'port' option to all the junos_\* modules allowing the user to supply a non-default (i.e. other than 830) port for connecting to the device.

This last change is useful with SSH tunnelling and other port translation techniques. It is not intended to be used to support poor NETCONF implementations.
