### PR TITLE
Adds support for the "replace:" statement

### DIFF
--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -204,10 +204,13 @@ def junos_install_config(module, dev):
             replace = module.boolean(module.params['replace'])
             if True == overwrite:
                 load_args['overwrite'] = True
+                load_args['merge'] = False
             elif False == overwrite:
                 load_args['merge'] = True
-            elif False == replace:
+                load_args['overwrite'] = False
+            if True == replace:
                 load_args['merge'] = False
+                load_args['overwrite'] = False
             cu.load(**load_args)
         except ValueError as err:
             logging.error("unable to load config:{0}".format(err.message))

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -84,6 +84,13 @@ options:
         required: false
         default: no
         choices: ['true','false','yes','no']
+    replace:
+        description:
+            - Specify whether the configuration I(file) uses "replace:" statements.
+              (NETCONF only)
+        required: false
+        default: no
+        choices: ['true','false','yes','no']
     timeout:
         description:
             - Extend the NETCONF RPC timeout beyond the default value of
@@ -194,10 +201,13 @@ def junos_install_config(module, dev):
             logging.info("loading config")
             load_args = {'path': file_path}
             overwrite = module.boolean(module.params['overwrite'])
+            replace = module.boolean(module.params['replace'])
             if True == overwrite:
                 load_args['overwrite'] = True
             elif False == overwrite:
                 load_args['merge'] = True
+            elif False == replace:
+                load_args['merge'] = False
             cu.load(**load_args)
         except ValueError as err:
             logging.error("unable to load config:{0}".format(err.message))
@@ -367,6 +377,7 @@ def main():
             console=dict(required=False, default=None),
             file=dict(required=True),
             overwrite=dict(required=False, choices=BOOLEANS, default=False),
+            replace=dict(required=False, choices=BOOLEANS, default=False),
             logfile=dict(required=False, default=None),
             diffs_file=dict(required=False, default=None),
             savedir=dict(required=False),


### PR DESCRIPTION
Supported on Junos_PyEZ, this allows configuration files with the "replace:" statement to be pushed and correctly interpreted (similar to a "load replace" on Juniper CLIs.

Please let me know if I need to change anything.