### PR TITLE
support commit confirm

### DIFF
--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -126,6 +126,12 @@ options:
             - TCP port number to use when connecting to the device
         required: false
         default: 830
+    confirm:
+        description:
+            - Using commit confirmed, number of minutes until automatic
+              rollback
+        required: false
+        default: None
 '''
 
 EXAMPLES = '''
@@ -238,8 +244,11 @@ def junos_install_config(module, dev):
                 cu.commit_check()
             else:
                 logging.info("committing change, please be patient")
-                if args['comment'] is not None:
-                    cu.commit(comment=args['comment'])
+                if args['confirm'] is not None:
+                    if args['comment'] is not None:
+                        cu.commit(confirm=args['confirm'], comment=args['comment'])
+                    else:
+                        cu.commit(comment=args['comment'])
                 else:
                     cu.commit()
                 results['changed'] = True
@@ -372,7 +381,8 @@ def main():
             savedir=dict(required=False),
             timeout=dict(required=False, default=0),
             comment=dict(required=False, default=None),
-            port=dict(required=False, default=830)
+            port=dict(required=False, default=830),
+            confirm=dict(required=False, default=None)
         ),
         supports_check_mode=True)
 


### PR DESCRIPTION
Hello

I don't expect this to be merged just like that but I'm more interested in opening up for a discussion. JUNOS and commit confirmed is really awesome and so is Ansible and wait_for. Example usage: http://p.ip.fi/OWJg
The commit_check.py script of course uses py-junos-eznc and connects to the device and does a commit_check().
