### PR TITLE
Bump req. pyez version to 1.2.1

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -45,7 +45,7 @@ description:
       and returns the information as a JSON dictionary.
       The information is similar to facts gathered by other IT frameworks.
 requirements:
-    - junos-eznc >= 1.1.0
+    - junos-eznc >= 1.2.1
     - junos-netconify >= 1.0.0, when using the I(console) option
 options:
     host:
@@ -115,7 +115,7 @@ import os
 
 
 def main():
-    import re
+    from distutils.version import LooseVersion
     module = AnsibleModule(
         argument_spec=dict(
             host=dict(required=True),
@@ -134,10 +134,10 @@ def main():
         try:
             from jnpr.junos import Device
             from jnpr.junos.version import VERSION
-            if not float(re.match('\d+.\d+', VERSION).group()) >= 1.1:
-                module.fail_json(msg='junos-eznc >= 1.1.x is required for this module')
+            if not LooseVersion(VERSION) >= LooseVersion('1.2.1'):
+                module.fail_json(msg='junos-eznc >= 1.2.1 is required for this module')
         except ImportError:
-            module.fail_json(msg='junos-eznc >= 1.1.x is required for this module')
+            module.fail_json(msg='junos-eznc >= 1.2.1 is required for this module')
         # -----------
         # via NETCONF
         # -----------
@@ -160,7 +160,7 @@ def main():
         try:
             from netconify.cmdo import netconifyCmdo
             from netconify.constants import version
-            if not float(re.match('\d+.\d+', version).group()) >= 1.0:
+            if not LooseVersion(version) >= LooseVersion('1.0'):
                 module.fail_json(msg='junos-netconify >= 1.0.x is required for this module')
         except ImportError:
             module.fail_json(msg='junos-netconify >= 1.0.x is required for this module')

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -51,7 +51,7 @@ description:
       NETCONF include ASCII text, Junos XML elements, and Junos OS B(set) commands.
       Configurations performed through the console must only use ASCII text formatting.
 requirements:
-    - junos-eznc >= 1.1.0
+    - junos-eznc >= 1.2.1
     - junos-netconify >= 1.0.0, when using the I(console) option
 options:
     host:
@@ -153,14 +153,14 @@ EXAMPLES = '''
 import logging
 from os.path import isfile
 import os
-import re
+from distutils.version import LooseVersion
 
 try:
     from jnpr.junos import Device
     from jnpr.junos.exception import *
     from jnpr.junos.utils.config import Config
     from jnpr.junos.version import VERSION
-    if not float(re.match('\d+.\d+', VERSION).group()) >= 1.1:
+    if not LooseVersion(VERSION) >= LooseVersion('1.2.1'):
         HAS_PYEZ = False
     else:
         HAS_PYEZ = True
@@ -302,7 +302,7 @@ def _load_via_console(module):
     try:
         from netconify.cmdo import netconifyCmdo
         from netconify.constants import version
-        if not float(re.match('\d+.\d+', version).group()) >= 1.0:
+        if not LooseVersion(version) >= LooseVersion('1.0'):
             module.fail_json(msg='junos-netconify >= 1.0.x is required for this module')
     except ImportError:
         module.fail_json(msg='junos-netconify >= 1.0.x is required for this module')
@@ -377,7 +377,7 @@ def main():
         supports_check_mode=True)
 
     if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.1.x is required for this module')
+        module.fail_json(msg='junos-eznc >= 1.2.1 is required for this module')
 
     args = module.params
 

--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -60,7 +60,7 @@ description:
       version matches the desired version.
 
 requirements:
-    - py-junos-eznc >= 1.1.0
+    - py-junos-eznc >= 1.2.1
 options:
     host:
         description:
@@ -127,10 +127,11 @@ EXAMPLES = '''
 import logging
 import re
 import os
+from distutils.version import LooseVersion
 try:
     from jnpr.junos import Device
     from jnpr.junos.version import VERSION
-    if not float(re.match('\d+.\d+', VERSION).group()) >= 1.1:
+    if not LooseVersion(VERSION) >= LooseVersion('1.2.1'):
         HAS_PYEZ = False
     else:
         HAS_PYEZ = True
@@ -237,7 +238,7 @@ def main():
     )
 
     if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.1.x is required for this module')
+        module.fail_json(msg='junos-eznc >= 1.2.1 is required for this module')
 
     args = module.params
 

--- a/library/junos_shutdown
+++ b/library/junos_shutdown
@@ -44,7 +44,7 @@ description:
       This is equivalent to executing either the Junos OS B(request system power-off)
       or B(request system reboot) operational command.
 requirements:
-    - junos-eznc >= 1.1.0
+    - junos-eznc >= 1.2.1
 options:
     host:
         description:
@@ -84,13 +84,13 @@ EXAMPLES = '''
     shutdown="shutdown"
     reboot=yes
 '''
+from distutils.version import LooseVersion
 
 try:
     from jnpr.junos import Device
     from jnpr.junos.utils.sw import SW
     from jnpr.junos.version import VERSION
-    import re
-    if not float(re.match('\d+.\d+', VERSION).group()) >= 1.1:
+    if not LooseVersion(VERSION) >= LooseVersion('1.2.1'):
         HAS_PYEZ = False
     else:
         HAS_PYEZ = True
@@ -112,7 +112,7 @@ def main():
         supports_check_mode=False)
 
     if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.1.x is required for this module')
+        module.fail_json(msg='junos-eznc >= 1.2.1 is required for this module')
 
     args = module.params
     if args['shutdown'] != 'shutdown':

--- a/library/junos_zeroize
+++ b/library/junos_zeroize
@@ -52,7 +52,7 @@ description:
       configuration. After the reboot, you must log in through the console
       as root in order to access the device.
 requirements:
-    - junos-eznc >= 1.1.0
+    - junos-eznc >= 1.2.1
     - junos-netconify >= 1.0.0, when using the I(console) option
 options:
     host:
@@ -106,7 +106,7 @@ EXAMPLES = '''
 
 import os
 import logging
-import re
+from distutils.version import LooseVersion
 
 
 def main():
@@ -152,10 +152,10 @@ def main():
         try:
             from jnpr.junos import Device
             from jnpr.junos.version import VERSION
-            if not float(re.match('\d+.\d+', VERSION).group()) >= 1.1:
-                module.fail_json(msg='junos-eznc >= 1.1.x is required for this module')
+            if not LooseVersion(VERSION) >= LooseVersion('1.2.1'):
+                module.fail_json(msg='junos-eznc >= 1.2.1 is required for this module')
         except ImportError:
-            module.fail_json(msg='junos-eznc >= 1.1.x is required for this module')
+            module.fail_json(msg='junos-eznc >= 1.2.1 is required for this module')
 
         dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'])
         try:
@@ -175,7 +175,7 @@ def main():
         try:
             from netconify.cmdo import netconifyCmdo
             from netconify.constants import version
-            if not float(re.match('\d+.\d+', version).group()) >= 1.0:
+            if not LooseVersion(version) >= LooseVersion('1.0'):
                 module.fail_json(msg='junos-netconify >= 1.0.x is required for this module')
         except ImportError:
             module.fail_json(msg='junos-netconify >= 1.0.x is required for this module')


### PR DESCRIPTION
Bump up required PyEZ version to 1.2.1
Switch from re to LooseVersion to test version (way cooler)
Resolves #64 