### PR TITLE
Refactor junos_install_config netconf into single funtion

### DIFF
--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -186,20 +186,40 @@ except ImportError:
     HAS_PYEZ = False
 
 
-def junos_install_config(module, dev):
+def _load_via_netconf(module):
     args = module.params
-    cu = Config(dev)
+
+    logfile = args['logfile']
+    if logfile is not None:
+        logging.basicConfig(filename=logfile, level=logging.INFO,
+                            format='%(asctime)s:%(name)s:%(message)s')
+        logging.getLogger().name = 'CONFIG:' + args['host']
 
     in_check_mode = module.check_mode
-
     overwrite = module.boolean(module.params['overwrite'])
     replace = module.boolean(module.params['replace'])
 
     if all([overwrite, replace]):
         msg = "Overwrite and Replace cannot both be True!"
         logging.error(msg)
-        results = {'failed': True, 'msg': msg}
-        return results
+        module.fail_json(msg=msg)
+
+    logging.info("connecting to host: {0}@{1}:{2}".format(args['user'], args['host'], args['port']))
+
+    try:
+        dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'])
+        dev.open(gather_facts=False)
+    except Exception as err:
+        msg = 'unable to connect to {0}: {1}'.format(args['host'], str(err))
+        logging.error(msg)
+        module.fail_json(msg=msg)
+        return
+
+    timeout = int(args['timeout'])
+    if timeout > 0:
+        dev.timeout = timeout
+
+    cu = Config(dev)
 
     results = {}
 
@@ -214,56 +234,61 @@ def junos_install_config(module, dev):
         logging.info("taking lock")
         cu.lock()
 
+    except LockError:
+        msg = "Unable to lock configuration"
+        logging.error(msg)
+        module.fail_json(msg=msg)
+
+    try:
+        # load the config.  the cu.load will raise
+        # an exception if there is even a warning.
+        # so we want to avoid that condition.
+        logging.info("loading config")
+        load_args = {'path': file_path}
+        if replace is True:
+            load_args['merge'] = False
+        elif overwrite is True:
+            load_args['overwrite'] = True
+        elif overwrite is False:
+            load_args['merge'] = True
+        cu.load(**load_args)
+    except (ValueError, ConfigLoadError, Exception) as err:
+        msg = "Unable to load config: {0}".format(err)
+        logging.error(msg)
         try:
-            # load the config.  the cu.load will raise
-            # an exception if there is even a warning.
-            # so we want to avoid that condition.
-            logging.info("loading config")
-            load_args = {'path': file_path}
-            if replace is True:
-                load_args['merge'] = False
-            elif overwrite is True:
-                load_args['overwrite'] = True
-            elif overwrite is False:
-                load_args['merge'] = True
-            cu.load(**load_args)
-        except ValueError as err:
-            logging.error("unable to load config:{0}".format(err.message))
-            raise err
-        except ConfigLoadError as err:
-            logging.error("unable to load config:{0},{1},{2}".format(err.errs['severity'],
-                                                                     err.errs['bad_element'],
-                                                                     err.errs['message']))
-            raise err
-        except Exception as err:
-            if err.rsp.find('.//ok') is None:
-                rpc_msg = err.rsp.findtext('.//error-message')
-                logging.error("unable to load config:{0}".format(rpc_msg))
-            raise err
-        else:
-            pass
+            logging.info("unlocking")
+            cu.unlock()
+        except UnlockError as err:
+            logging.error("Unable to unlock config: {0}".format(err))
+        dev.close()
+        module.fail_json(msg=msg)
 
-        diff = cu.diff()
+    diff = cu.diff()
 
-        if diff is not None:
-            diffs_file = args['diffs_file']
-            if diffs_file is not None:
-                try:
-                    f = open(diffs_file, 'w')
-                    f.write(diff)
-                    f.close()
-                except IOError as (errno, strerror):
-                    msg = "Problem with diffs_file {0}: ".format(diffs_file)
-                    msg += "I/O Error: ({0}): {1}".format(errno, strerror)
-                    module.fail_json(msg=msg)
-                except:
-                    msg = "Problem with diffs_file {0}: ".format(diffs_file)
-                    msg += "Unexpected error:", sys.exc_info()[0]
-                    module.fail_json(msg=msg)
+    if diff is not None:
+        diffs_file = args['diffs_file']
+        if diffs_file is not None:
+            try:
+                f = open(diffs_file, 'w')
+                f.write(diff)
+                f.close()
+            except IOError as (errno, strerror):
+                msg = "Problem with diffs_file {0}: ".format(diffs_file)
+                msg += "I/O Error: ({0}): {1}".format(errno, strerror)
+                logging.error(msg)
+                module.fail_json(msg=msg)
+            except:
+                msg = "Problem with diffs_file {0}: ".format(diffs_file)
+                msg += "Unexpected error:", sys.exc_info()[0]
+                logging.error(msg)
+                module.fail_json(msg=msg)
 
+        try:
+            logging.info("doing a commit-check, please be patient")
+            cu.commit_check()
             if (in_check_mode):
-                logging.info("doing a commit-check, please be patient")
-                cu.commit_check()
+                logging.info("Ansible check mode complete")
+                module.exit_json(**results)
             else:
                 logging.info("committing change, please be patient")
                 opts = {}
@@ -275,56 +300,25 @@ def junos_install_config(module, dev):
                 cu.commit(**opts)
                 results['changed'] = True
 
-        logging.info("unlocking")
-        cu.unlock()
-        logging.info("change completed")
-
-    except LockError:
-        results['failed'] = True
-        msg = "Unable to lock configuration"
-        results['msg'] = msg
-        logging.error(msg)
-
-    except CommitError as err:
-        results['failed'] = True
-        msg = "Unable to commit configuration:{0},{1},{2}".format(err.errs['severity'],
-                                                                  err.errs['bad_element'],
-                                                                  err.errs['message'])
-        results['msg'] = msg
-        logging.error(msg)
-
-    except Exception as err:
-        results['failed'] = True
-        msg = "Unable to make changes"
-        results['msg'] = msg
-        logging.error(msg)
-
-    return results
-
-
-def _load_via_netconf(module):
-    args = module.params
-
-    logfile = args['logfile']
-    if logfile is not None:
-        logging.basicConfig(filename=logfile, level=logging.INFO,
-                            format='%(asctime)s:%(name)s:%(message)s')
-        logging.getLogger().name = 'CONFIG:' + args['host']
-
-    logging.info("connecting to host: {0}@{1}:{2}".format(args['user'], args['host'], args['port']))
+        except CommitError as err:
+            msg = "Unable to commit configuration: {0}".format(err)
+            logging.error(msg)
+            try:
+                logging.info("unlocking")
+                cu.unlock()
+            except UnlockError as err:
+                logging.error("Unable to unlock config: {0}".format(err))
+            dev.close()
+            module.fail_json(msg=msg)
 
     try:
-        dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'])
-        dev.open()
-    except Exception as err:
-        msg = 'unable to connect to {0}: {1}'.format(args['host'], str(err))
-        module.fail_json(msg=msg)
-        return
+        logging.info("unlocking")
+        cu.unlock()
+    except UnlockError as err:
+        logging.error("Unable to unlock config: {0}".format(err))
 
-    timeout = int(args['timeout'])
-    if timeout > 0:
-        dev.timeout = timeout
-    results = junos_install_config(module, dev)
+    logging.info("change completed")
+
     dev.close()
     module.exit_json(**results)
 


### PR DESCRIPTION
This update moves the NETCONF stuff into a single function.
Proper exception handling has been included as well as a commit_check prior to actual commit.
*Note* This will prevent configurations with warnings from committing.  This is the default behavior of PyEZ <=1.2.  Future versions of PyEZ will support multiple rpc-error elements and as such a new exception class will be created to handle warnings only.

```
TASK: [Install config] ********************************************************
failed: [pabst.englab.juniper.net] => {"failed": true}
msg: Unable to commit configuration: CommitError(edit_path: [edit security policies from-zone corp to-zone], bad_element: corp, message: mgd: Security zone must be defined)

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/home/rsherman/config.retry

pabst.englab.juniper.net   : ok=0    changed=0    unreachable=0    failed=1
```

```
2015-07-29 17:14:42,789:CONFIG:pabst.englab.juniper.net:connecting to host: regress@pabst.englab.juniper.net:830
2015-07-29 17:14:48,957:CONFIG:pabst.englab.juniper.net:pushing file: /home/rsherman/workspace/warning.set
2015-07-29 17:14:48,957:CONFIG:pabst.englab.juniper.net:taking lock
2015-07-29 17:14:49,230:CONFIG:pabst.englab.juniper.net:loading config
2015-07-29 17:14:50,333:CONFIG:pabst.englab.juniper.net:doing a commit-check, please be patient
2015-07-29 17:14:51,823:CONFIG:pabst.englab.juniper.net:Unable to commit configuration: CommitError(edit_path: [edit security policies from-zone corp to-zone], bad_element: corp, message: mgd: Security zone must be defined)
2015-07-29 17:14:51,823:CONFIG:pabst.englab.juniper.net:unlocking
```

Resolves #56 
Resolves #58 