### PR TITLE
Add junos_get_config

### DIFF
--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+
+# Copyright (c) 1999-2015, Juniper Networks Inc.
+#               2014, Jeremy Schulman
+#               2015, Rick Sherman
+#
+# All rights reserved.
+#
+# License: Apache 2.0
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the Juniper Networks nor the
+#   names of its contributors may be used to endorse or promote products
+#   derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY Juniper Networks, Inc. ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL Juniper Networks, Inc. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DOCUMENTATION = '''
+---
+module: junos_get_config
+author: Rick Sherman, Juniper Networks
+version_added: "1.2.0"
+short_description: Retrieve configuration of device
+description:
+    - Retrieve the configuration of a device running Junos and save it to a file.
+      B(Note) unicode chars will be converted to '??' as also done in PyEZ
+requirements:
+    - junos-eznc >= 1.2.2
+options:
+    host:
+        description:
+            - Set to {{ inventory_hostname }}
+        required: true
+    user:
+        description:
+            - Login username
+        required: false
+        default: $USER
+    passwd:
+        description:
+            - Login password
+        required: false
+        default: assumes ssh-key active
+    port:
+        description:
+            - TCP port number to use when connecting to the device
+        required: false
+        default: 830
+    logfile:
+        description:
+            - Path on the local server where the progress status is logged
+              for debugging purposes
+        required: false
+        default: None
+    dest:
+        description:
+            - Path to the local server directory where configuration will
+              be saved.
+        required: true
+        default: None
+    format:
+        description:
+            - text - configuration saved as text (curly-brace) format
+            - xml - configuration saved as XML
+        required: false
+        choices: ['text','xml']
+        default: 'text'
+    options:
+        description:
+            - Additional options to pass to get_config. Refer
+              to B(jnpr.junos.rpcmeta.get_config) for details.
+        required: false
+        default: None
+    filter:
+        description:
+            - Defines heircachy of configuration to retrieve.  If omitted
+              entire configuration is retrieved.  Format is slash notation
+              ex I(groups/routeinst/routing-instances/ISP-1)
+        required: false
+        default: None
+'''
+
+EXAMPLES = '''
+- junos_get_config:
+   host: "{{ inventory_hostname }}"
+   logfile: get_config.log
+   dest: "{{ inventory_hostname }}.xml"
+   format: xml
+   filter: "interfaces"
+   options: {inherit: inherit, groups: groups}
+'''
+from distutils.version import LooseVersion
+import logging
+from lxml import etree
+from lxml.builder import E
+
+try:
+    from jnpr.junos import Device
+    from jnpr.junos.version import VERSION
+    from jnpr.junos.exception import RpcError
+    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+        HAS_PYEZ = False
+    else:
+        HAS_PYEZ = True
+except ImportError:
+    HAS_PYEZ = False
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(host=dict(required=True, default=None),  # host or ipaddr
+                           user=dict(required=False, default=os.getenv('USER')),
+                           passwd=dict(required=False, default=None),
+                           port=dict(required=False, default=830),
+                           logfile=dict(required=False, default=None),
+                           dest=dict(required=False, default=None),
+                           format=dict(required=False, choices=['text', 'xml'], default='text'),
+                           options=dict(required=False, default=None),
+                           filter=dict(required=False, default=None)
+                           ),
+        supports_check_mode=True)
+
+    if not HAS_PYEZ:
+        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+
+    args = module.params
+
+    logfile = args['logfile']
+    if logfile is not None:
+        logging.basicConfig(filename=logfile, level=logging.INFO,
+                            format='%(asctime)s:%(name)s:%(message)s')
+        logging.getLogger().name = 'CONFIG:' + args['host']
+
+    logging.info("connecting to host: {0}@{1}:{2}".format(args['user'], args['host'], args['port']))
+
+    try:
+        dev = Device(args['host'], user=args['user'], password=args['passwd'],
+                     port=args['port'], gather_facts=False).open()
+    except Exception as err:
+        msg = 'unable to connect to {0}: {1}'.format(args['host'], str(err))
+        logging.error(msg)
+        module.fail_json(msg=msg)
+        # --- UNREACHABLE ---
+
+    try:
+        options = args['options'] or {}
+        options['format'] = args['format']
+
+        filter_xml = None
+        if args['filter']:
+            flist = args['filter'].split('/')
+            if flist[0] == 'configuration':
+                filter_xml = E(flist.pop(0))
+            else:
+                filter_xml = E('configuration')
+
+            for f in flist:
+                filter_xml.append(E(f))
+
+            logging.info("Getting config with filter={0}".format(etree.tostring(filter_xml)))
+
+        logging.info("Getting config with options={0}".format(options))
+
+        config = dev.rpc.get_config(options=options, filter_xml=filter_xml)
+
+        with open(args['dest'], 'w') as confile:
+            if args['format'] == 'text':
+                confile.write(config.text.encode('ascii', 'replace'))
+            elif args['format'] == 'xml':
+                confile.write(etree.tostring(config))
+
+    except (ValueError, RpcError) as err:
+        msg = 'Unable to get config: {0}'.format(str(err))
+        logging.error(msg)
+        dev.close()
+        module.fail_json(msg=msg)
+
+    except Exception as err:
+        msg = 'Uncaught exception - please report: {0}'.format(str(err))
+        logging.error(msg)
+        dev.close()
+        module.fail_json(msg=msg)
+
+    dev.close()
+
+    module.exit_json()
+
+from ansible.module_utils.basic import *
+main()


### PR DESCRIPTION
This adds the ability to retrieve the configuration of a device and save it to a file.
get_config options and filters are supported.

```yaml
---
  - name: Get Device Config
    hosts: all
    connection: local
    gather_facts: no

    tasks:
     - name: Get configuration
       junos_get_config:
        host: "{{ inventory_hostname }}"
        user:
        passwd:
        logfile: get_config.log
        dest: "{{ inventory_hostname }}.xml"
        format: xml
        filter: "interfaces"
        options: {inherit: inherit, groups: groups}
       register: junos
```

```
2015-07-30 15:32:55,952:CONFIG:pabst.englab.juniper.net:connecting to host: user@pabst.englab.juniper.net:830
2015-07-30 15:33:02,036:CONFIG:pabst.englab.juniper.net:Getting config with filter=<configuration><interfaces/></configuration>
2015-07-30 15:33:02,036:CONFIG:pabst.englab.juniper.net:Getting config with options={'groups': 'groups', 'inherit': 'inherit', 'format': 'xml'}
```

```xml
<configuration changed-seconds="1438235510" changed-localtime="2015-07-30 05:51:50 UTC">
    <interfaces group="re0">
        <interface group="re0">
            <name group="re0">ge-0/0/0</name>
            <unit group="re0">
                <name group="re0">0</name>
                <family group="re0">
                    <inet group="re0">
                        <address group="re0">
                            <name group="re0">192.168.164.114/22</name>
                        </address>
                    </inet>
                </family>
            </unit>
        </interface>
        <interface group="re0">
            <name group="re0">lo0</name>
            <unit group="re0">
                <name group="re0">0</name>
                <family group="re0">
                    <inet group="re0">
                        <address group="re0">
                            <name group="re0">10.255.7.41/32</name>
                        </address>
                        <address group="global">
                            <name group="global">127.0.0.1/32</name>
                        </address>
                    </inet>
                </family>
            </unit>
        </interface>
    </interfaces>
</configuration>
```

Resolves #1