### PR TITLE
Use consistent shebang syntax in all Python modules

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_shutdown
+++ b/library/junos_shutdown
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman

--- a/library/junos_srx_cluster
+++ b/library/junos_srx_cluster
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Patrik Bok

--- a/library/junos_zeroize
+++ b/library/junos_zeroize
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 1999-2014, Juniper Networks Inc.
 #               2014, Jeremy Schulman


### PR DESCRIPTION
Quick fix to update all the shebangs in `library/` to use `/usr/bin/env python` instead of hardcoding to `/usr/bin/python`.

Note: Hardcoding specific Python runtimes like `/usr/bin/python` breaks execution environments like virtualenv that install new Python versions on the `PATH`