### PR TITLE
Added the ability to use jinja templating with junos_install_config

### DIFF
--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -77,6 +77,11 @@ options:
               extension, the content is treated as Junos OS B(set)
               commands.
         required: true
+    template_vars_file:
+        description:
+            - Path to the file containing a JSON string that gets
+              converted to a dict and fed to PyEZ for jinja templating
+        required: false
     overwrite:
         description:
             - Specify whether the configuration I(file) completely replaces
@@ -198,6 +203,7 @@ def _load_via_netconf(module):
     in_check_mode = module.check_mode
     overwrite = module.boolean(module.params['overwrite'])
     replace = module.boolean(module.params['replace'])
+    template_vars_file = module.params['template_vars_file']
 
     if all([overwrite, replace]):
         msg = "Overwrite and Replace cannot both be True!"
@@ -244,7 +250,22 @@ def _load_via_netconf(module):
         # an exception if there is even a warning.
         # so we want to avoid that condition.
         logging.info("loading config")
-        load_args = {'path': file_path}
+        load_args = {}
+
+        # normal config load from a 'static' file
+        if template_vars_file is not None:
+            # template config load from template,
+            # so load the template vars file
+            load_args['template_path'] = file_path
+
+            template_vars_file = os.path.abspath(template_vars_file)
+            logging.info("reading from template vars file: {0}".format(template_vars_file))
+            with open(template_vars_file) as vars_file:
+                load_args['template_vars'] = json.load(vars_file)
+
+        else:
+            load_args['path'] = file_path
+
         if replace is True:
             load_args['merge'] = False
         elif overwrite is True:
@@ -391,6 +412,7 @@ def main():
             passwd=dict(required=False, default=None),
             console=dict(required=False, default=None),
             file=dict(required=True),
+            template_vars_file=dict(required=False, default=None),
             overwrite=dict(required=False, choices=BOOLEANS, default=False),
             replace=dict(required=False, choices=BOOLEANS, default=False),
             logfile=dict(required=False, default=None),


### PR DESCRIPTION
Since pyEZ already supports templating with jinja by feeding a dict to the cu.load() call, I just added a new ansible module parameter called "template_vars_file" that gets read in, passed through json.load(), and then put in with the load_args array that gets fed to cu.load().  I don't think using the json module will cause any dependency changes, but in the event it does, we could always fall back to the uglier "eval" solution (and assuming we want to put up with cries of bad security).  Please note that the following example is extremely simplified / contrived as to show the use of this.  There are obviously better use cases.

Examples:
## Playbook (ansible-op-scripts-playbook.yml)

```
lamoni@ubuntu:~/playbooks$ cat ansible-op-scripts-playbook.yml 

---
- name: Load merge a configuration to a device running Junos OS
  hosts: srx1
  roles:
  - Juniper.junos 
  connection: local
  gather_facts: no

  tasks: 
  - name: Checking NETCONF connectivity
    wait_for: host={{ inventory_hostname }} port=830  timeout=5

  - name: load merge a configuration file
    junos_install_config: 
      host={{ inventory_hostname }}
      file=/home/lamoni/playbooks/op_script.set
      template_vars_file=/home/lamoni/playbooks/op_script.json
      overwrite=false
      logfile=/var/log/ansible/junos/config.log
```
## Junos Config File (op_script.set)

```
lamoni@ubuntu:~/playbooks$ cat op_script.set
set system scripts op file {{ scriptName }}
```
## JSON Template Vars File (op_script.json)

```
{"scriptName":"somenewscript.slax"}
```
