### PR TITLE
Support for 'changed' attribute to get_config

### DIFF
--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -143,6 +143,7 @@ def main():
         module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
 
     args = module.params
+    results = {}
 
     logfile = args['logfile']
     if logfile is not None:
@@ -182,11 +183,25 @@ def main():
 
         config = dev.rpc.get_config(options=options, filter_xml=filter_xml)
 
-        with open(args['dest'], 'w') as confile:
-            if args['format'] == 'text':
-                confile.write(config.text.encode('ascii', 'replace'))
-            elif args['format'] == 'xml':
-                confile.write(etree.tostring(config))
+        ## Compare existing file (if exists) with new output
+        if args['format'] == 'text':
+            newconf = config.text.encode('ascii', 'replace')
+        elif args['format'] == 'xml':
+            newconf = etree.tostring(config)
+
+        oldconf = ''
+        if os.path.isfile(args['dest']):
+            with open(args['dest'], 'r') as confile:
+                oldconf = confile.read()
+
+        ## Correctly report 'changed' attribute
+        if oldconf != newconf:
+            results['changed'] = True
+
+        ## if check_mode, then don't actually change the dest file!
+        if not module.check_mode:
+            with open(args['dest'], 'w') as confile:
+                confile.write(newconf)
 
     except (ValueError, RpcError) as err:
         msg = 'Unable to get config: {0}'.format(str(err))
@@ -202,7 +217,7 @@ def main():
 
     dev.close()
 
-    module.exit_json()
+    module.exit_json(**results)
 
 from ansible.module_utils.basic import *
 main()

--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -132,7 +132,7 @@ def main():
                            passwd=dict(required=False, default=None),
                            port=dict(required=False, default=830),
                            logfile=dict(required=False, default=None),
-                           dest=dict(required=False, default=None),
+                           dest=dict(required=True, default=None),
                            format=dict(required=False, choices=['text', 'xml'], default='text'),
                            options=dict(required=False, default=None),
                            filter=dict(required=False, default=None)


### PR DESCRIPTION
Properly reports 'changed' attribute and supports check_mode for junos_get_config module.

I also fixed the requirement status for the `dest` argument (docs claimed True, but set to False when module was called).