### PR TITLE
Add a timeout argument to the junos_commit module

### DIFF
--- a/library/junos_commit
+++ b/library/junos_commit
@@ -63,6 +63,13 @@ options:
             - TCP port number to use when connecting to the device
         required: false
         default: 830
+    timeout:
+        description:
+            - Extend the NETCONF RPC timeout beyond the default value of
+              30 seconds. Set this value to accommodate commits that
+              might take longer than the default timeout interval.
+        required: false
+        default: "0"
     logfile:
         description:
             - Path on the local server where the progress status is logged
@@ -110,6 +117,7 @@ def main():
                            user=dict(required=False, default=os.getenv('USER')),
                            passwd=dict(required=False, default=None),
                            port=dict(required=False, default=830),
+                           timeout=dict(required=False, default=0),
                            logfile=dict(required=False, default=None),
                            comment=dict(required=False, default=None),
                            confirm=dict(required=False, default=None)
@@ -142,6 +150,10 @@ def main():
         # --- UNREACHABLE ---
 
     try:
+        timeout = int(args['timeout'])
+        if timeout > 0:
+            dev.timeout = timeout
+
         cu = Config(dev)
 
         logging.info("taking lock")


### PR DESCRIPTION
Add a timeout argument to the junos_commit module to support confirming a commit on a device which is slow and/or has a large config.