### PR TITLE
fixing log message and setting results variable when enabling cluster…

### DIFF
--- a/library/junos_srx_cluster
+++ b/library/junos_srx_cluster
@@ -181,7 +181,8 @@ def main():
         if cluster is True:
             if (args['cluster_id'] and args['node']) is not None:
                 do_it = dev.rpc.set_chassis_cluster_enable(cluster_id=args['cluster_id'], node=args['node'], reboot=True)
-                logging.info('Device message: {0}'.format(do_it.findtext('.//message').strip()))
+                logging.info('Device message: {0}'.format(do_it.getparent().findtext('.//output').strip()))
+                results = {"changed": True, "reboot": True}
             else:
                 msg = 'FAIL: Cluster and Node ID required with enable_cluster=YES'
                 logging.error(msg)


### PR DESCRIPTION
… via the NETCONF API (but not via the console)

While testing the junos_srx_cluster module I discovered that the code that set the cluster via pure NETCONF (rather than NETCONF via console) has a couple of bugs.

First it was looking for the wrong response tag in the wrong location. The first line change fixes that.

Second the if block did not set the results variable. As such the module exited without the required variable being set. The second line fixes that.

If you find the changes agreeable please accept this merge request.