### PR TITLE
Enhancement/config diff

### DIFF
--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -143,6 +143,7 @@ def main():
         module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
 
     args = module.params
+    results = {}
 
     logfile = args['logfile']
     if logfile is not None:
@@ -182,11 +183,25 @@ def main():
 
         config = dev.rpc.get_config(options=options, filter_xml=filter_xml)
 
-        with open(args['dest'], 'w') as confile:
-            if args['format'] == 'text':
-                confile.write(config.text.encode('ascii', 'replace'))
-            elif args['format'] == 'xml':
-                confile.write(etree.tostring(config))
+        ## Compare existing file (if exists) with new output
+        if args['format'] == 'text':
+            newconf = config.text.encode('ascii', 'replace')
+        elif args['format'] == 'xml':
+            newconf = etree.tostring(config)
+
+        oldconf = ''
+        if os.path.isfile(args['dest']):
+            with open(args['dest'], 'r') as confile:
+                oldconf = confile.read()
+
+        ## Correctly report 'changed' attribute
+        if oldconf != newconf:
+            results['changed'] = True
+
+        ## if check_mode, then don't actually change the dest file!
+        if not module.check_mode:
+            with open(args['dest'], 'w') as confile:
+                confile.write(newconf)
 
     except (ValueError, RpcError) as err:
         msg = 'Unable to get config: {0}'.format(str(err))
@@ -202,7 +217,7 @@ def main():
 
     dev.close()
 
-    module.exit_json()
+    module.exit_json(**results)
 
 from ansible.module_utils.basic import *
 main()

--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -197,6 +197,13 @@ def main():
         ## Correctly report 'changed' attribute
         if oldconf != newconf:
             results['changed'] = True
+            if getattr(module,'_diff',False) is True:
+                results['diff'] = dict(
+                    before = oldconf,
+                    after = newconf,
+                    before_header = args['dest'],
+                    after_header = args['host'],
+                )
 
         ## if check_mode, then don't actually change the dest file!
         if not module.check_mode:

--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -132,7 +132,7 @@ def main():
                            passwd=dict(required=False, default=None),
                            port=dict(required=False, default=830),
                            logfile=dict(required=False, default=None),
-                           dest=dict(required=False, default=None),
+                           dest=dict(required=True, default=None),
                            format=dict(required=False, choices=['text', 'xml'], default='text'),
                            options=dict(required=False, default=None),
                            filter=dict(required=False, default=None)

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -266,7 +266,7 @@ def _load_via_netconf(module):
     diff = cu.diff()
 
     if diff is not None:
-        if getattr(module,'_diff',False):
+        if getattr(module,'_diff',False) is True:
             results['diff'] = dict(
                 prepared = diff
             )

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -266,6 +266,10 @@ def _load_via_netconf(module):
     diff = cu.diff()
 
     if diff is not None:
+        if getattr(module,'_diff',False):
+            results['diff'] = dict(
+                prepared = diff
+            )
         diffs_file = args['diffs_file']
         if diffs_file is not None:
             try:

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -266,6 +266,7 @@ def _load_via_netconf(module):
     diff = cu.diff()
 
     if diff is not None:
+        results['changed'] = True
         if getattr(module,'_diff',False) is True:
             results['diff'] = dict(
                 prepared = diff
@@ -302,7 +303,6 @@ def _load_via_netconf(module):
                     opts['confirm'] = args['confirm']
 
                 cu.commit(**opts)
-                results['changed'] = True
 
         except CommitError as err:
             msg = "Unable to commit configuration: {0}".format(err)


### PR DESCRIPTION
I added a few things:

1. junos_get_config now supports check_mode (as opposed to claiming that it did, but overwriting the `dest` file anyway).
2. Properly reports 'changed' attribute for junos_get_config module.
3. Fixed the requirement status for the dest argument in junos_get_config (docs claimed True, but set to False when module was called).
4. If `--diff` on cmdline*, return diff diff with results.
   - In junos_get_config, sets `before` and `after` attributes and lets Ansible do the diff.
   - In junos_install_config, sets `prepared` with the output of `commit check`.


\* Currently, Ansible 2.0.0.2 does not report this, but the devel branch shows setting `module._diff` as well as reading `diff['prepared']` from returned results. While this pull request will ignore `--diff` cmdline args in 2.0.0.2, it will accept and properly handle that option when Ansible upgrades.
