### PR TITLE
Addressing issue #102.

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -152,6 +152,9 @@ def main():
             dev.close()
             dev.facts['has_2RE'] = dev.facts['2RE']
             del dev.facts['2RE']  # Ansible doesn't allow variables starting with numbers
+            # Ansible 2 doesn't like custom objects in the return value.
+            # Convert the version_info key from a junos.version_info object to a dict
+            dev.facts['version_info'] = dict(dev.facts['version_info'])
             m_results['facts'] = dev.facts
             if m_args['savedir'] is not None:
                 fname = "{0}/{1}-facts.json".format(m_args['savedir'], dev.facts['hostname'])


### PR DESCRIPTION
Ansible 2 adds a feature to search the modules return value for any
strings which should not be logged. This feature only handles built-in
data types and does not handle custom objects.

The junos_get_facts module was returning a junos.version_info object
which caused this new feature to raise a TypeError.

Since all Ansible return values are passed via JSON, the junos.version_info
object was previously getting converted to a dictionary anyway, so this
change should be backwards compatible with Ansible 1 as well.