### PR TITLE
Add role junos_cli to execute CLI on device and save output locally

### DIFF
--- a/library/junos_cli
+++ b/library/junos_cli
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+
+# Copyright (c) 1999-2015, Juniper Networks Inc.
+#               2014, Jeremy Schulman
+#               2015, Rick Sherman
+#
+# All rights reserved.
+#
+# License: Apache 2.0
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of the Juniper Networks nor the
+#   names of its contributors may be used to endorse or promote products
+#   derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY Juniper Networks, Inc. ''AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL Juniper Networks, Inc. BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+DOCUMENTATION = '''
+---
+module: junos_cli
+author: Damien Garros, Juniper Networks
+version_added: "1.2.0"
+short_description: Execute CLI/RPC on device and save the output locally
+description:
+    - Execute CLI/RPC on device and save the output locally on a file
+requirements:
+    - junos-eznc >= 1.2.2
+options:
+    host:
+        description:
+            - Set to {{ inventory_hostname }}
+        required: true
+    user:
+        description:
+            - Login username
+        required: false
+        default: $USER
+    cli:
+        description:
+            - CLI command to execute on the host
+        required: true
+    passwd:
+        description:
+            - Login password
+        required: false
+        default: assumes ssh-key active
+    port:
+        description:
+            - TCP port number to use when connecting to the device
+        required: false
+        default: 830
+    logfile:
+        description:
+            - Path on the local server where the progress status is logged
+              for debugging purposes
+        required: false
+        default: None
+    dest:
+        description:
+            - Path to the local server directory where cli output will
+              be saved.
+        required: true
+        default: None
+    format:
+        description:
+            - text - Cli output saved in text format
+            - xml - Cli output saved as XML
+        required: false
+        choices: ['text','xml']
+        default: 'text'
+'''
+
+EXAMPLES = '''
+- junos_cli:
+   host: "{{ inventory_hostname }}"
+   cli: "show chassis hardware"
+   logfile: cli.log
+   dest: "{{ inventory_hostname }}.xml"
+   format: xml
+'''
+from distutils.version import LooseVersion
+import logging
+from lxml import etree
+from lxml.builder import E
+
+try:
+    from jnpr.junos import Device
+    from jnpr.junos.version import VERSION
+    from jnpr.junos.exception import RpcError
+    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+        HAS_PYEZ = False
+    else:
+        HAS_PYEZ = True
+except ImportError:
+    HAS_PYEZ = False
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(host=dict(required=True, default=None),  # host or ipaddr
+                           cli=dict(required=True, default=None),
+                           user=dict(required=False, default=os.getenv('USER')),
+                           passwd=dict(required=False, default=None),
+                           port=dict(required=False, default=830),
+                           logfile=dict(required=False, default=None),
+                           dest=dict(required=False, default=None),
+                           format=dict(required=False, choices=['text', 'xml'], default='text')
+                           ),
+        supports_check_mode=True)
+
+    if not HAS_PYEZ:
+        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+
+    args = module.params
+
+    logfile = args['logfile']
+    if logfile is not None:
+        logging.basicConfig(filename=logfile, level=logging.INFO,
+                            format='%(asctime)s:%(name)s:%(message)s')
+        logging.getLogger().name = 'CONFIG:' + args['host']
+
+    logging.info("connecting to host: {0}@{1}:{2}".format(args['user'], args['host'], args['port']))
+
+    try:
+        dev = Device(args['host'], user=args['user'], password=args['passwd'],
+                     port=args['port'], gather_facts=False).open()
+    except Exception as err:
+        msg = 'unable to connect to {0}: {1}'.format(args['host'], str(err))
+        logging.error(msg)
+        module.fail_json(msg=msg)
+        # --- UNREACHABLE ---
+
+    try:
+        options = {}
+        options['format'] = args['format']
+
+        logging.info("Getting cli output")
+
+        cli_output = dev.cli(command=args['cli'], format=args['format'] )
+
+        with open(args['dest'], 'w') as outputfile:
+            if args['format'] == 'text':
+                outputfile.write(cli_output)
+            elif args['format'] == 'xml':
+                outputfile.write(etree.tostring(cli_output))
+
+    except (ValueError, RpcError) as err:
+        msg = 'Unable to get cli output: {0}'.format(str(err))
+        logging.error(msg)
+        dev.close()
+        module.fail_json(msg=msg)
+
+    except Exception as err:
+        msg = 'Uncaught exception - please report: {0}'.format(str(err))
+        logging.error(msg)
+        dev.close()
+        module.fail_json(msg=msg)
+
+    dev.close()
+
+    module.exit_json()
+
+from ansible.module_utils.basic import *
+main()


### PR DESCRIPTION
Hi
I created a new role to simply execute a show /request cli command on a device and save the result locally
As discussed, it will be great to convert XML to JSON properly and feed JSON natively into Ansible, this part is not available today 

Thanks
Damien