### PR TITLE
Add a parameter to only do a commit check

### DIFF
--- a/library/junos_commit
+++ b/library/junos_commit
@@ -89,6 +89,7 @@ options:
     check:
         description:
             - Do a commit check
+              Can be used to confirm a `commit confirmed` without performing an actual commit
         required: false
         default: None
 '''

--- a/library/junos_commit
+++ b/library/junos_commit
@@ -86,6 +86,11 @@ options:
             - Provide a confirm in minutes to the commit of the configuration
         required: false
         default: None
+    check:
+        description:
+            - Do a commit check
+        required: false
+        default: None
 '''
 
 EXAMPLES = '''
@@ -120,7 +125,8 @@ def main():
                            timeout=dict(required=False, default=0),
                            logfile=dict(required=False, default=None),
                            comment=dict(required=False, default=None),
-                           confirm=dict(required=False, default=None)
+                           confirm=dict(required=False, default=None),
+                           check=dict(required=False, choices=BOOLEANS, default=False)
                            ),
         supports_check_mode=True)
 
@@ -158,8 +164,8 @@ def main():
 
         logging.info("taking lock")
         cu.lock()
-
-        if (in_check_mode):
+        check = args['check']
+        if (in_check_mode or check):
             logging.info("doing a commit-check, please be patient")
             cu.commit_check()
         else:


### PR DESCRIPTION
This is useful when doing first a "commit confirm" followed directly by a "commit check".
That way, if the commit breaks connectivity to the device, the configuration rollbacks, if there is still connectivity the commit check is faster than a full commit and doesn't trigger configuration archival, etc..

Example:

``` yaml
- name: "Do a commit confirmed 2 or commit check"
  junos_install_config:
    host={{ inventory_hostname }}
    port=22
    file="{{ assembled_conf }}"
    overwrite=false
    replace=true
    diffs_file="{{ logs_dir }}/{{ inventory_hostname }}.diff"
    logfile="{{ logs_dir }}/{{ inventory_hostname }}.log"
    timeout="300"
    comment="Ansible"
    confirm="2"
  register: push_result

- name: "commit check to confirm the previous commit"
  junos_commit:
   host={{ inventory_hostname }}
   check=true
  when: not check_mode and push_result.changed
```
