### PR TITLE
Fix typo in timeout in junos_cli, simplified default timeout handling

### DIFF
--- a/library/junos_cli
+++ b/library/junos_cli
@@ -68,11 +68,11 @@ options:
         default: 830
     timeout:
         description:
-            - Extend the NETCONF RPC timeout beyond the default value of
-              30 seconds. Set this value to accommodate Cli commands
+            - Set the NETCONF RPC timeout (default value of
+              30 seconds). Set this value to accommodate Cli commands
               that might take longer than the default timeout interval.
         required: false
-        default: "0"
+        default: "30"
     logfile:
         description:
             - Path on the local server where the progress status is logged
@@ -127,7 +127,7 @@ def main():
                            user=dict(required=False, default=os.getenv('USER')),
                            passwd=dict(required=False, default=None),
                            port=dict(required=False, default=830),
-                           timeout=dict(required=False, default=0),
+                           timeout=dict(required=False, type='int', default=30),
                            logfile=dict(required=False, default=None),
                            dest=dict(required=False, default=None),
                            format=dict(required=False, choices=['text', 'xml'], default='text')
@@ -157,9 +157,7 @@ def main():
         # --- UNREACHABLE ---
 
     ## Change default Timeout
-    timeout = int(m_args['timeout'])
-    if timeout > 0:
-        dev.timeout = timeout
+    dev.timeout = args['timeout']
 
     try:
         options = {}

--- a/library/junos_cli
+++ b/library/junos_cli
@@ -68,11 +68,11 @@ options:
         default: 830
     timeout:
         description:
-            - Set the NETCONF RPC timeout (default value of
-              30 seconds). Set this value to accommodate Cli commands
-              that might take longer than the default timeout interval.
+            - Set the NETCONF RPC timeout. Set this value to accommodate Cli
+              commands that might take longer than the default timeout interval.
+              Setting to 0 will use the PyEZ default (30 seconds).
         required: false
-        default: "30"
+        default: "0"
     logfile:
         description:
             - Path on the local server where the progress status is logged
@@ -127,7 +127,7 @@ def main():
                            user=dict(required=False, default=os.getenv('USER')),
                            passwd=dict(required=False, default=None),
                            port=dict(required=False, default=830),
-                           timeout=dict(required=False, type='int', default=30),
+                           timeout=dict(required=False, type='int', default=0),
                            logfile=dict(required=False, default=None),
                            dest=dict(required=False, default=None),
                            format=dict(required=False, choices=['text', 'xml'], default='text')
@@ -157,7 +157,8 @@ def main():
         # --- UNREACHABLE ---
 
     ## Change default Timeout
-    dev.timeout = args['timeout']
+    if args['timeout'] > 0:
+        dev.timeout = args['timeout']
 
     try:
         options = {}

--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -93,11 +93,11 @@ options:
         default: 'xml'
     timeout:
         description:
-            - Set the NETCONF RPC timeout (default value of
-              30 seconds). Set this value to accommodate RPCs
-              that might take longer than the default timeout interval.
+            - Set the NETCONF RPC timeout. Set this value to accommodate Cli
+              commands that might take longer than the default timeout interval.
+              Setting to 0 will use the PyEZ default (30 seconds).
         required: false
-        default: "30"
+        default: "0"
     dest:
         description:
             - Path to the local server directory where configuration will
@@ -234,7 +234,7 @@ def main():
             user=dict(required=False, default=os.getenv('USER')),
             passwd=dict(required=False, default=None),
             port=dict(required=False, default=830),
-            timeout=dict(required=False, type='int', default=30),
+            timeout=dict(required=False, type='int', default=0),
             rpc=dict(required=True, default=None),
             kwargs=dict(required=False, default=None),
             filter_xml=dict(required=False, default=None),
@@ -256,7 +256,8 @@ def main():
         return
 
     ## Change default Timeout
-    dev.timeout = m_args['timeout']
+    if m_args['timeout'] > 0:
+        dev.timeout = m_args['timeout']
 
     results = junos_rpc(module, dev)
 

--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -93,11 +93,11 @@ options:
         default: 'xml'
     timeout:
         description:
-            - Extend the NETCONF RPC timeout beyond the default value of
-              30 seconds. Set this value to accommodate RPCs
+            - Set the NETCONF RPC timeout (default value of
+              30 seconds). Set this value to accommodate RPCs
               that might take longer than the default timeout interval.
         required: false
-        default: "0"
+        default: "30"
     dest:
         description:
             - Path to the local server directory where configuration will
@@ -234,7 +234,7 @@ def main():
             user=dict(required=False, default=os.getenv('USER')),
             passwd=dict(required=False, default=None),
             port=dict(required=False, default=830),
-            timeout=dict(required=False, default=0),
+            timeout=dict(required=False, type='int', default=30),
             rpc=dict(required=True, default=None),
             kwargs=dict(required=False, default=None),
             filter_xml=dict(required=False, default=None),
@@ -256,9 +256,7 @@ def main():
         return
 
     ## Change default Timeout
-    timeout = int(m_args['timeout'])
-    if timeout > 0:
-        dev.timeout = timeout
+    dev.timeout = m_args['timeout']
 
     results = junos_rpc(module, dev)
 


### PR DESCRIPTION
there was a typo in junos_cli, module arguments in that file are in 'args' but the code for timeout was copy/pasted form junos_rpc where they are in 'm_args'

The rest is just some cleanup around handling the default value and casting types.