### PR TITLE
Added 'set_facts_as' option to get_junos_facts to register 'facts'

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -74,6 +74,12 @@ options:
               I(savedir/hostname-facts.json)
         required: false
         default: $CWD
+    set_facts_as:
+        description:
+            - include ansible_facts dictionary key in output and copy 'facts'
+              key to ansible_facts.<provided_key>
+        required: false
+        default: None
     logfile:
         description:
             - Path on the local server where the progress status is logged
@@ -124,7 +130,8 @@ def main():
             savedir=dict(required=False, default=None),
             user=dict(required=False, default=os.getenv('USER')),
             passwd=dict(required=False, default=None),
-            port=dict(required=False, default=830)),
+            port=dict(required=False, default=830),
+            set_facts_as=dict(required=False, default=None)),
         supports_check_mode=True)
 
     m_args = module.params
@@ -205,6 +212,9 @@ def main():
             module.fail_json(msg=str(err))
         m_results['args'] = m_args        # for debug
         m_results['facts'] = c_results['facts']
+
+    if m_args['set_facts_as'] is not None:
+        m_results['ansible_facts'] = {m_args['set_facts_as']: m_results['facts']}
 
     module.exit_json(**m_results)
 


### PR DESCRIPTION
using `set_facts_as: key` in a task will copy the returned 'facts' into `ansible_facts.key` so that they will be automatically registered by ansible. This is different from just simply doing `register: key` because it will ONLY register the facts and not the entire output which contains unnecessary information (arguments, password, etc) . It also preserves backwards compatibility with existing scripts by not changing existing behavior.

```
- name: Gather Juniper Facts
  junos_get_facts:
    host: "{{ inventory_hostname }}"
    passwd: "{{ passwd }}"
    set_facts_as: vendor_facts
- name: Debug Vendor Facts
  debug: var=vendor_facts
```
