### PR TITLE
Update junos_get_config

### DIFF
--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -175,8 +175,9 @@ def main():
             current_element = filter_xml
 
             for f in flist:
-                current_element = etree.SubElement(current_element,f)
-
+                current_element.append(etree.SubElement(current_element,f))
+            
+            filter_xml = current_element
             logging.info("Getting config with filter={0}".format(etree.tostring(filter_xml)))
 
         logging.info("Getting config with options={0}".format(options))


### PR DESCRIPTION
This is a fix for issue #145. Works for me while current master does not.

This is nice but what I really want is the inverse functionality, e.g exclude parts of the config from archival. Something like the following:

exclude_filter:
              - "interfaces/interface/fxp0"
              - "groups/member0"

This would result in a config being retrieved but minus the sections matching the list of xpath statements. It is also quite confusing that the existing example of "filter" function looks a little like it might be xpath but is not. Well at least it confused me. :-P
