### PR TITLE
Timeout option for junos_get_config module

### DIFF
--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -76,6 +76,13 @@ options:
               be saved.
         required: true
         default: None
+    timeout:
+        description:
+            - Extend the NETCONF RPC timeout beyond the default value of
+              30 seconds. Set this value to accommodate config request
+              that might take longer than the default timeout interval.
+        required: false
+        default: "0"
     format:
         description:
             - text - configuration saved as text (curly-brace) format
@@ -130,6 +137,7 @@ def main():
                            user=dict(required=False, default=os.getenv('USER')),
                            passwd=dict(required=False, default=None),
                            port=dict(required=False, default=830),
+                           timeout=dict(required=False, default=0),
                            logfile=dict(required=False, default=None),
                            dest=dict(required=True, default=None),
                            format=dict(required=False, choices=['text', 'xml'], default='text'),
@@ -160,6 +168,10 @@ def main():
         logging.error(msg)
         module.fail_json(msg=msg)
         # --- UNREACHABLE ---
+
+    timeout = int(args['timeout'])
+    if timeout > 0:
+        dev.timeout = timeout
 
     try:
         options = args['options'] or {}


### PR DESCRIPTION
This adds timeout option to junos_get_config module.

Default value is not enough when you have large configuration and/or slow routing engine.
`fatal: [ROUTER]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to get config: RpcTimeoutError(host: 1.1.1.1, cmd: get-configuration, timeout: 30)"}`
