### PR TITLE
fix regex to match xe/ge/et interfaces

### DIFF
--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -190,7 +190,7 @@ def junos_rpc(module, dev):
         elif re.search(r'\{.*\}', kwargs):
             values = {k:v for k,v in re.findall(r'([\w-]+)\s?:\s?\'?\"?([\w\.-]+)\'?\"?',kwargs)}
         else:
-            values = {k:v for k,v in re.findall('([\w-]+)=([\w\.-]+)', kwargs)}
+            values = {k:v for k,v in re.findall('([\w-]+)=([\w\.\-\/]+)', kwargs)}
         for k,v in values.items():
             if v in ['True', 'true']:
                 values[k]=True


### PR DESCRIPTION
I need the regex to match all the following:
```
kwargs=vme
kwargs=xe-0/0/0
kwargs=fpx0
kwargs=me0.0
```
Current state don't match xe/ge/et itnerfaces due to forward slash not in the regex expression.