### PR TITLE
ImportError proper message

### DIFF
--- a/library/junos_cli
+++ b/library/junos_cli
@@ -107,18 +107,6 @@ import logging
 from lxml import etree
 from lxml.builder import E
 
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    from jnpr.junos.exception import RpcError
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
-
-
 def main():
 
     module = AnsibleModule(
@@ -134,10 +122,16 @@ def main():
                            ),
         supports_check_mode=True)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        from jnpr.junos.exception import RpcError
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
 
     logfile = args['logfile']
     if logfile is not None:

--- a/library/junos_commit
+++ b/library/junos_commit
@@ -94,21 +94,9 @@ EXAMPLES = '''
    logfile=changes.log
    comment="Non load commit"
 '''
+
 from distutils.version import LooseVersion
 import logging
-
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    from jnpr.junos.utils.config import Config
-    from jnpr.junos.exception import CommitError, LockError, UnlockError
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
-
 
 def main():
 
@@ -124,13 +112,20 @@ def main():
                            ),
         supports_check_mode=True)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
     in_check_mode = module.check_mode
-
     results = dict(changed=False)
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        from jnpr.junos.utils.config import Config
+        from jnpr.junos.exception import CommitError, LockError, UnlockError
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
+
 
     logfile = args['logfile']
     if logfile is not None:

--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -111,18 +111,6 @@ from distutils.version import LooseVersion
 import logging
 from lxml import etree
 
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    from jnpr.junos.exception import RpcError
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
-
-
 def main():
 
     module = AnsibleModule(
@@ -138,10 +126,17 @@ def main():
                            ),
         supports_check_mode=True)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        from jnpr.junos.exception import RpcError
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
+
     results = {}
 
     logfile = args['logfile']

--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -112,10 +112,9 @@ EXAMPLES = '''
 
 import os
 import json
-
+from distutils.version import LooseVersion
 
 def main():
-    from distutils.version import LooseVersion
     module = AnsibleModule(
         argument_spec=dict(
             host=dict(required=True),
@@ -136,8 +135,8 @@ def main():
             from jnpr.junos.version import VERSION
             if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
                 module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-        except ImportError:
-            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+        except ImportError as ex:
+            module.fail_json(msg='ImportError: %s' % ex.message)
         # -----------
         # via NETCONF
         # -----------

--- a/library/junos_get_table
+++ b/library/junos_get_table
@@ -120,19 +120,8 @@ import logging
 import os
 from lxml import etree
 from lxml.builder import E
-from jnpr.junos.factory.factory_loader import FactoryLoader
 import yaml
 
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    import jnpr.junos.op as tables_dir
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
 
 TABLE_PATH = os.path.dirname(os.path.abspath(tables_dir.__file__))
 CHOICES = ['list_of_dicts', 'juniper_items']
@@ -178,10 +167,17 @@ def main():
                            ),
         supports_check_mode=False)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        import jnpr.junos.op as tables_dir
+        from jnpr.junos.factory.factory_loader import FactoryLoader
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
 
     logfile = args['logfile']
     response_type = args['response_type']

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -179,17 +179,6 @@ from os.path import isfile
 import os
 from distutils.version import LooseVersion
 
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.exception import *
-    from jnpr.junos.utils.config import Config
-    from jnpr.junos.version import VERSION
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
 
 
 def _load_via_netconf(module):
@@ -419,11 +408,18 @@ def main():
         ),
         supports_check_mode=True)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
 
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.exception import *
+        from jnpr.junos.utils.config import Config
+        from jnpr.junos.version import VERSION
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
+    
     # ------------------------------
     # make sure file actually exists
     # ------------------------------

--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -128,16 +128,6 @@ import logging
 import re
 import os
 from distutils.version import LooseVersion
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
-
 
 def junos_install_os(module, dev):
     args = module.params
@@ -220,7 +210,6 @@ def junos_install_os(module, dev):
 
 
 def main():
-    #
     module = AnsibleModule(
         argument_spec=dict(
             host=dict(required=True),
@@ -236,11 +225,16 @@ def main():
         ),
         supports_check_mode=True
     )
-
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
+
 
     # @@@ need to verify that the package file actually exists
     # @@@ before proceeding.

--- a/library/junos_jsnapy
+++ b/library/junos_jsnapy
@@ -123,21 +123,8 @@ from distutils.version import LooseVersion
 import logging
 from lxml import etree
 from lxml.builder import E
-
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    from jnpr.junos.exception import RpcError
-    from jnpr.jsnapy import SnapAdmin
-    import os
-    import time
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError as ex:
-    HAS_PYEZ = False
-
+import os
+import time
 
 def jsnap_selection(dev, module):
 
@@ -195,11 +182,18 @@ def main():
         required_one_of=[['test_files', 'config_file']],
         supports_check_mode=False)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
     results = {}
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        from jnpr.junos.exception import RpcError
+        from jnpr.jsnapy import SnapAdmin
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
 
     logfile = args['logfile']
     if logfile is not None:

--- a/library/junos_ping
+++ b/library/junos_ping
@@ -136,15 +136,6 @@ import sys
 import re
 from lxml import etree
 from distutils.version import LooseVersion
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
 
 def main():
     module = AnsibleModule(
@@ -166,11 +157,16 @@ def main():
         supports_check_mode=False
     )
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     results = {}
     m_args = module.params
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
 
     # Open connection to device
     dev = Device(

--- a/library/junos_rollback
+++ b/library/junos_rollback
@@ -110,19 +110,6 @@ EXAMPLES = '''
 from distutils.version import LooseVersion
 import logging
 
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.version import VERSION
-    from jnpr.junos.utils.config import Config
-    from jnpr.junos.exception import CommitError, LockError, UnlockError, RpcError
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
-
-
 def main():
 
     module = AnsibleModule(
@@ -139,11 +126,18 @@ def main():
                            ),
         supports_check_mode=True)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-
     args = module.params
     in_check_mode = module.check_mode
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        from jnpr.junos.utils.config import Config
+        from jnpr.junos.exception import CommitError, LockError, UnlockError, RpcError
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
 
     results = dict(changed=False)
 

--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -165,7 +165,6 @@ import os
 import sys
 import logging
 import re
-from jnpr.junos import Device
 from lxml import etree
 
 def junos_rpc(module, dev):
@@ -243,6 +242,15 @@ def main():
         supports_check_mode=False)
 
     m_args = module.params
+
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.version import VERSION
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
+
     # -----------
     # via NETCONF
     # -----------

--- a/library/junos_shutdown
+++ b/library/junos_shutdown
@@ -97,18 +97,6 @@ EXAMPLES = '''
 '''
 from distutils.version import LooseVersion
 
-try:
-    from jnpr.junos import Device
-    from jnpr.junos.utils.sw import SW
-    from jnpr.junos.version import VERSION
-    if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
-        HAS_PYEZ = False
-    else:
-        HAS_PYEZ = True
-except ImportError:
-    HAS_PYEZ = False
-
-
 def main():
 
     module = AnsibleModule(
@@ -124,8 +112,14 @@ def main():
         ),
         supports_check_mode=False)
 
-    if not HAS_PYEZ:
-        module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    try:
+        from jnpr.junos import Device
+        from jnpr.junos.utils.sw import SW
+        from jnpr.junos.version import VERSION
+        if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
+            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+    except ImportError as ex:
+        module.fail_json(msg='ImportError: %s' % ex.message)
 
     args = module.params
     if args['shutdown'] != 'shutdown':

--- a/library/junos_srx_cluster
+++ b/library/junos_srx_cluster
@@ -162,8 +162,8 @@ def main():
             from jnpr.junos.version import VERSION
             if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
                 module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-        except ImportError:
-            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+        except ImportError as ex:
+            module.fail_json(msg='ImportError: %s' % ex.message)
 
         dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'], gather_facts=('false'))
         try:

--- a/library/junos_zeroize
+++ b/library/junos_zeroize
@@ -154,8 +154,8 @@ def main():
             from jnpr.junos.version import VERSION
             if not LooseVersion(VERSION) >= LooseVersion('1.2.2'):
                 module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
-        except ImportError:
-            module.fail_json(msg='junos-eznc >= 1.2.2 is required for this module')
+        except ImportError as ex:
+            module.fail_json(msg='ImportError: %s' % ex.message)
 
         dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'])
         try:


### PR DESCRIPTION
Now if ImportError is due to different package, error will give proper message
```
$ ansible-playbook facts_gather.yml 

PLAY ***************************************************************************

TASK [gather facts] ************************************************************
fatal: [10.221.150.172]: FAILED! => {"changed": false, "failed": true, "msg": "ImportError: No module named lxml"}
```