### PR TITLE
"compare" mode is added. 

### DIFF
--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -165,6 +165,14 @@ options:
             - Provide a confirm in minutes to the commit of the configuration
         required: false
         default: None
+    check_commit:
+        description:
+            - Specify whether the configuration will be commit-checked or not.
+              Set to false, outputs similarly to the "show | compare" functionality,
+              while true returns the "commit check" result.
+        required: false
+        default: yes
+        choices: ['true','false','yes','no']
     ignore_warning:
         description:
             - A boolean, string or list of string.
@@ -250,6 +258,7 @@ def _load_via_netconf(module):
         logging.getLogger().name = 'CONFIG:' + args['host']
 
     in_check_mode = module.check_mode
+    check_commit = module.boolean(module.params['check_commit'])
     overwrite = module.boolean(module.params['overwrite'])
     replace = module.boolean(module.params['replace'])
     update = module.boolean(module.params['update'])
@@ -362,39 +371,40 @@ def _load_via_netconf(module):
                 logging.error(msg)
                 module.fail_json(msg=msg)
 
-        try:
-            logging.info("doing a commit-check, please be patient")
-            cu.commit_check()
-            if (in_check_mode):
-                logging.info("Ansible check mode complete")
-                module.exit_json(**results)
-            else:
-                logging.info("committing change, please be patient")
-                opts = {}
-                if args['ignore_warning'] is not None:
-                    opts = {'ignore_warning': args['ignore_warning']}
-                if args['comment'] is not None:
-                    opts['comment'] = args['comment']
-                if args['confirm'] is not None:
-                    opts['confirm'] = args['confirm']
-
-                if args['check_commit_wait']:
-                   check_commit_wait = int(args['check_commit_wait'])
-                   if 1 <= check_commit_wait <= 4:
-                      time.sleep(check_commit_wait)
-
-                cu.commit(**opts)
-
-        except CommitError as err:
-            msg = "Unable to commit configuration: {0}".format(err)
-            logging.error(msg)
+        if check_commit:
             try:
-                logging.info("unlocking")
-                cu.unlock()
-            except UnlockError as err:
-                logging.error("Unable to unlock config: {0}".format(err))
-            dev.close()
-            module.fail_json(msg=msg)
+                logging.info("doing a commit-check, please be patient")
+                cu.commit_check()
+                if (in_check_mode):
+                    logging.info("Ansible check mode complete")
+                    module.exit_json(**results)
+                else:
+                    logging.info("committing change, please be patient")
+                    opts = {}
+                    if args['ignore_warning'] is not None:
+                        opts = {'ignore_warning': args['ignore_warning']}
+                    if args['comment'] is not None:
+                        opts['comment'] = args['comment']
+                    if args['confirm'] is not None:
+                        opts['confirm'] = args['confirm']
+
+                    if args['check_commit_wait']:
+                       check_commit_wait = int(args['check_commit_wait'])
+                       if 1 <= check_commit_wait <= 4:
+                          time.sleep(check_commit_wait)
+
+                    cu.commit(**opts)
+
+            except CommitError as err:
+                msg = "Unable to commit configuration: {0}".format(err)
+                logging.error(msg)
+                try:
+                    logging.info("unlocking")
+                    cu.unlock()
+                except UnlockError as err:
+                    logging.error("Unable to unlock config: {0}".format(err))
+                dev.close()
+                module.fail_json(msg=msg)
 
     try:
         logging.info("unlocking")
@@ -488,6 +498,7 @@ def main():
             ssh_private_key_file=dict(required=False, default=None),
             mode=dict(required=False, default=None),
             confirm=dict(required=False, default=None),
+            check_commit=dict(required=False, type='bool', choices=BOOLEANS, default=True),
             ignore_warning=dict(required=False, default=None),
             check_commit_wait=dict(required=False, default=None)
         ),


### PR DESCRIPTION
Using the latter, one can compare the generated configuration changes against the running configuration. Changes are not staged to the equipment. Similar to "show | compare" in Juniper edit mode.
