### PR TITLE
Don't log password to stdout

### DIFF
--- a/library/junos_cli
+++ b/library/junos_cli
@@ -128,7 +128,7 @@ def main():
         argument_spec=dict(host=dict(required=True, default=None),  # host or ipaddr
                            cli=dict(required=True, default=None),
                            user=dict(required=False, default=os.getenv('USER')),
-                           passwd=dict(required=False, default=None),
+                           passwd=dict(required=False, default=None, no_log=True),
                            port=dict(required=False, default=830),
                            mode=dict(required=False, default=None),
                            timeout=dict(required=False, type='int', default=0),

--- a/library/junos_commit
+++ b/library/junos_commit
@@ -117,7 +117,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(host=dict(required=True, default=None),  # host or ipaddr
                            user=dict(required=False, default=os.getenv('USER')),
-                           passwd=dict(required=False, default=None),
+                           passwd=dict(required=False, default=None, no_log=True),
                            port=dict(required=False, default=830),
                            mode=dict(required=False, default=None),
                            timeout=dict(required=False, default=0),

--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -131,7 +131,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(host=dict(required=True, default=None),  # host or ipaddr
                            user=dict(required=False, default=os.getenv('USER')),
-                           passwd=dict(required=False, default=None),
+                           passwd=dict(required=False, default=None, no_log=True),
                            port=dict(required=False, default=830),
                            mode=dict(required=False, default=None),
                            logfile=dict(required=False, default=None),

--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -141,7 +141,7 @@ def main():
             logfile=dict(required=False, default=None),
             savedir=dict(required=False, default=None),
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             port=dict(required=False, default=830),
             mode=dict(required=False, default=None)),
         supports_check_mode=True)

--- a/library/junos_get_table
+++ b/library/junos_get_table
@@ -180,7 +180,7 @@ def main():
                            default=None),  # host or ipaddr
                            user=dict(required=False,
                                      default=os.getenv('USER')),
-                           passwd=dict(required=False, default=None),
+                           passwd=dict(required=False, default=None, no_log=True),
                            port=dict(required=False, default=830),
                            mode=dict(required=False, default=None),
                            logfile=dict(required=False, default=None),

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -420,7 +420,7 @@ def main():
         argument_spec=dict(
             host=dict(required=True),
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             console=dict(required=False, default=None),
             file=dict(required=True),
             overwrite=dict(required=False, type='bool', choices=BOOLEANS, default=False),

--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -215,7 +215,7 @@ def main():
             host=dict(required=True),
             package=dict(required=True),
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             version=dict(required=False, default=None),
             logfile=dict(required=False, default=None),
             no_copy=dict(required=False, type='bool', choices=BOOLEANS, default=False),

--- a/library/junos_jsnapy
+++ b/library/junos_jsnapy
@@ -233,7 +233,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(host=dict(required=True, default=None),  # host or ipaddr
                            user=dict(required=False, default=os.getenv('USER')),
-                           passwd=dict(required=False, default=None),
+                           passwd=dict(required=False, default=None, no_log=True),
                            port=dict(required=False, default=830),
                            mode=dict(required=False, default=None),
                            logfile=dict(required=False, default=None),

--- a/library/junos_ping
+++ b/library/junos_ping
@@ -159,7 +159,7 @@ def main():
         argument_spec=dict(
             host=dict(required=True),
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             port=dict(required=False, default=830),
             mode=dict(required=False, default=None),
             timeout=dict(required=False, default=0),

--- a/library/junos_rollback
+++ b/library/junos_rollback
@@ -133,7 +133,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(host=dict(required=True, default=None),  # host or ipaddr
                            user=dict(required=False, default=os.getenv('USER')),
-                           passwd=dict(required=False, default=None),
+                           passwd=dict(required=False, default=None, no_log=True),
                            port=dict(required=False, default=830),
                            mode=dict(required=False, default=None),
                            logfile=dict(required=False, default=None),

--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -247,7 +247,7 @@ def main():
             host=dict(required=True),
             logfile=dict(required=False, default=None),
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             port=dict(required=False, default=830),
             mode=dict(required=False, default=None),
             timeout=dict(required=False, type='int', default=0),

--- a/library/junos_shutdown
+++ b/library/junos_shutdown
@@ -118,7 +118,7 @@ def main():
             shutdown=dict(required=True, default=None),   # must be set to 'shutdown'
             host=dict(required=True, default=None),       # host or ipaddr
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             reboot=dict(required=False, type='bool', choices=BOOLEANS, default=False),
             port=dict(required=False, default=830),
             mode=dict(required=False, default=None),

--- a/library/junos_srx_cluster
+++ b/library/junos_srx_cluster
@@ -143,7 +143,7 @@ def main():
         argument_spec=dict(
             host=dict(required=True, default=None),       # host or ipaddr
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             port=dict(required=False, default=830),
             mode=dict(required=False, default=None),
             console=dict(required=False, default=None),     # param to netconify
@@ -186,7 +186,7 @@ def main():
         if args['mode'] is not None and LooseVersion(VERSION) < LooseVersion('2.0.0'):
             module.fail_json(msg='junos-eznc >= 2.0.0 is required for console connection')
 
-        dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'], 
+        dev = Device(args['host'], user=args['user'], password=args['passwd'], port=args['port'],
                      mode=args['mode'], gather_facts=False)
         try:
             logging.info('LOGIN: host={0} port={1}'.format(args['host'], args['port']))

--- a/library/junos_zeroize
+++ b/library/junos_zeroize
@@ -52,7 +52,7 @@ description:
       configuration. After the reboot, you must log in through the console
       as root in order to access the device.
 requirements:
-    - junos-eznc >= 1.2.2 
+    - junos-eznc >= 1.2.2
     - junos-netconify >= 1.0.1, when using the I(console) option
 options:
     host:
@@ -129,7 +129,7 @@ def main():
             host=dict(required=False, default=None),    # host or ipaddr
             console=dict(required=False, default=None),     # param to netconify
             user=dict(required=False, default=os.getenv('USER')),
-            passwd=dict(required=False, default=None),
+            passwd=dict(required=False, default=None, no_log=True),
             logfile=dict(required=False, default=None),
             port=dict(required=False, default=830),
             mode=dict(required=False, default=None)


### PR DESCRIPTION
Currently a run will show the password as plaintext, this minor change prevents logging such a sensitive variable. For example:

`fatal: [router01]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"check_commit_wait": null, "comment": null, "confirm": null, "console": null, "diffs_file": null, "file": "output/router01/compiled.set", "host": "192.0.2.40", "logfile": null, "mode": null, "overwrite": false, "passwd": "myUbers3ck3tpass!#@", "port": "830" ...`

With this change

`fatal: [router01]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"check_commit_wait": null, "comment": null, "confirm": null, "console": null, "diffs_file": null, "file": "output/router01/compiled.set", "host": "192.0.2.40", "logfile": null, "mode": null, "overwrite": false, "passwd": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "port": "830" ...`
