### PR TITLE
Require the dest argument to the junos_cli module.

### DIFF
--- a/library/junos_cli
+++ b/library/junos_cli
@@ -133,7 +133,7 @@ def main():
                            mode=dict(required=False, default=None),
                            timeout=dict(required=False, type='int', default=0),
                            logfile=dict(required=False, default=None),
-                           dest=dict(required=False, default=None),
+                           dest=dict(required=True, default=None),
                            format=dict(required=False, choices=['text', 'xml'], default='text')
                            ),
         supports_check_mode=True)


### PR DESCRIPTION
Addresses #190.