### PR TITLE
To support kwargs as dict into junos_rpc

### DIFF
--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -168,11 +168,13 @@ EXAMPLES = '''
   tasks:
     - name: Get interface information
       junos_rpc:
-        host={{ inventory_hostname }}
-        rpc=get-interface-information
-        kwargs={interface_name:em0,media:True}
-        format=json
-        dest=get_interface_information.conf
+        host: "{{ inventory_hostname }}"
+        rpc: get-interface-information
+        kwargs:
+          interface_name: em0
+          media: True
+        format: json
+        dest: get_interface_information.conf
       register: junos
 
     - name: Print configuration

--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -84,6 +84,9 @@ options:
                 kwargs="interface_name=em0" or kwargs="interface_name=em0,media=True"
                 kwargs={interface_name:em0}
                 kwargs={interface_name:em0,media:True}
+                kwargs:
+                  interface_name: em0
+                  media: True
     filter_xml:
         description:
             - This options can be used with get-config rpc only,
@@ -202,6 +205,8 @@ def junos_rpc(module, dev):
     try:
         if kwargs is None:
             values = {}
+        elif isinstance(kwargs, dict):
+            values = kwargs
         elif re.search(r'\{.*\}', kwargs):
             values = {k:v for k,v in re.findall(r'([\w-]+)\s?:\s?\'?\"?([\w\.-]+)\'?\"?',kwargs)}
         else:

--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -194,13 +194,12 @@ def junos_rpc(module, dev):
     if logfile is not None:
         logging.basicConfig(filename=logfile, level=logging.INFO,
                             format='%(asctime)s:%(name)s:%(message)s')
-        logging.getLogger().name = 'CONFIG:' + args['host']
+        logging.getLogger().name = 'JUNOS_RPC:' + args['host']
 
     results = {}
     kwargs = module.params['kwargs']
     rpc = module.params['rpc']
     results['rpc'] = rpc
-    results['kwargs'] = kwargs
     results['changed'] = False
     results['check_mode'] = module.check_mode
     logging.info("calling RPC: {0}".format(rpc))
@@ -210,14 +209,25 @@ def junos_rpc(module, dev):
         elif isinstance(kwargs, dict):
             values = kwargs
         elif re.search(r'\{.*\}', kwargs):
-            values = {k:v for k,v in re.findall(r'([\w-]+)\s?:\s?\'?\"?([\w\.-]+)\'?\"?',kwargs)}
+            try:
+                # When data is provided like
+                # kwargs:
+                #   interface_name: em0
+                #   media: True
+                values = eval(kwargs)
+            except:
+                # In case when data is provided as below
+                # kwargs={interface-name:em0,media:True}
+                values = {k:v for k,v in re.findall(r'([\w-]+)\s?:\s?\'?\"?([\w\.-]+)\'?\"?',kwargs)}
         else:
+            # kwargs="interface_name=em0,media=True"
             values = {k:v for k,v in re.findall('([\w-]+)=([\w\.\-\/]+)', kwargs)}
         for k,v in values.items():
             if v in ['True', 'true']:
                 values[k]=True
             elif v in ['False', 'false']:
                 values[k]=False
+        results['kwargs'] = values
         if rpc in ['get-config', 'get_config']:
             filter_xml = module.params['filter_xml']
             if filter_xml is not None:
@@ -266,7 +276,6 @@ def main():
         supports_check_mode=False)
 
     m_args = module.params
-
     try:
         from jnpr.junos import Device
         from jnpr.junos.version import VERSION


### PR DESCRIPTION
```yaml
  tasks:
    - name: Get interface information
      junos_rpc:
        host: "{{ inventory_hostname }}"
        rpc: get-interface-information
        kwargs:
          interface_name: em0
          media: True
```