### PR TITLE
Modify junos_get_facts to be compatible with Juniper/py-junos-eznc#638.

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -182,13 +182,31 @@ def main():
             module.fail_json(msg=msg)
             return
         else:
+            # Ansible 2 doesn't like custom objects in the return value, and
+            # PyEZ facts are now a custom object rather than a true dict.
+            # Since facts are read-only, we must begin by copying facts into a
+            # dict. Also, since PyEZ facts are now "on-demand", this must be
+            # done before closing the connection. These changes remain backwards
+            # compatible with older PyEZ versions that have older fact gathering
+            # code.
+            m_results['facts'] = dict(dev.facts)
             dev.close()
-            dev.facts['has_2RE'] = dev.facts['2RE']
-            del dev.facts['2RE']  # Ansible doesn't allow variables starting with numbers
-            # Ansible 2 doesn't like custom objects in the return value.
-            # Convert the version_info key from a junos.version_info object to a dict
-            dev.facts['version_info'] = dict(dev.facts['version_info'])
-            m_results['facts'] = dev.facts
+            # Ansible doesn't allow keys starting with numbers.
+            # Replace the '2RE' key with the 'has_2RE' key.
+            if '2RE' in m_results['facts']:
+                m_results['facts']['has_2RE'] = m_results['facts']['2RE']
+                del m_results['facts']['2RE']
+            # The value of the 'version_info' key is a custom junos.version_info
+            # object. Convert this value to a dict.
+            if 'version_info' in m_results['facts']:
+                m_results['facts']['version_info'] = dict(
+                    m_results['facts']['version_info'])
+            # The values of the ['junos_info'][re_name]['object'] keys are
+            # custom junos.version_info objects. Convert all of these to dicts.
+            if 'junos_info' in m_results['facts']:
+                for key in m_results['facts']['junos_info']:
+                    m_results['facts']['junos_info'][key]['object'] = dict(
+                        m_results['facts']['junos_info'][key]['object'])
             if m_args['savedir'] is not None:
                 fname = "{0}/{1}-facts.json".format(m_args['savedir'], dev.facts['hostname'])
                 with open(fname, 'w') as factfile:


### PR DESCRIPTION
Ansible 2 doesn't like custom objects in a module's return value, and
after Juniper/py-junos-eznc#638 PyEZ facts are now a custom object rather than a true
dict. Since facts are read-only, we must begin by copying facts into a dict.
Also, since PyEZ facts are now "on-demand", this must be done before closing
the connection. These changes remain backwards compatible with older PyEZ
versions that have older fact gathering code.