### PR TITLE
junos_get_config options type defined for Ansible >=2.1

### DIFF
--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -146,7 +146,7 @@ def main():
                            logfile=dict(required=False, default=None),
                            dest=dict(required=True, default=None),
                            format=dict(required=False, choices=['text', 'xml'], default='text'),
-                           options=dict(required=False, default=None),
+                           options=dict(required=False, default=None, type='dict'),
                            filter=dict(required=False, default=None)
                            ),
         supports_check_mode=True)


### PR DESCRIPTION
With Ansible version >=2.1, if the type is not defined, the value is assigned as string only.
Hence change to take explicitly define type of options param

refer: https://github.com/ansible/ansible/issues/19589
