### PR TITLE
Allow modules to import cleanly

### DIFF
--- a/library/junos_cli
+++ b/library/junos_cli
@@ -215,4 +215,6 @@ def main():
     module.exit_json()
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_commit
+++ b/library/junos_commit
@@ -228,4 +228,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_get_config
+++ b/library/junos_get_config
@@ -251,4 +251,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -242,4 +242,6 @@ def main():
     module.exit_json(**m_results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_install_config
+++ b/library/junos_install_config
@@ -461,4 +461,6 @@ def main():
     _ldr(module)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -273,4 +273,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_jsnapy
+++ b/library/junos_jsnapy
@@ -353,4 +353,6 @@ def main():
     module.exit_json(**data)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_ping
+++ b/library/junos_ping
@@ -305,4 +305,5 @@ def main():
 
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/library/junos_rollback
+++ b/library/junos_rollback
@@ -279,4 +279,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_rpc
+++ b/library/junos_rpc
@@ -318,4 +318,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_shutdown
+++ b/library/junos_shutdown
@@ -191,4 +191,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_srx_cluster
+++ b/library/junos_srx_cluster
@@ -266,4 +266,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()

--- a/library/junos_zeroize
+++ b/library/junos_zeroize
@@ -227,4 +227,6 @@ def main():
     module.exit_json(**results)
 
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Ansible 2.3 attempts to import modules to see if `USE_PERSISTENT_CONNECTION` is set. The modules are incorrectly executed upon import because they lack a `if __name__ == '__main__':` conditional.

This is an alternate way to address ansible/ansible#22590. I suggest that ansible/ansible#22590 should still be merged to avoid the problem for users which are running a version of these modules which don't yet have this fix.