### PR TITLE
JSON dump of Junos facts requires native Python data types.

### DIFF
--- a/library/junos_get_facts
+++ b/library/junos_get_facts
@@ -210,7 +210,7 @@ def main():
             if m_args['savedir'] is not None:
                 fname = "{0}/{1}-facts.json".format(m_args['savedir'], dev.facts['hostname'])
                 with open(fname, 'w') as factfile:
-                    json.dump(dev.facts, factfile)
+                    json.dump(m_results['facts'], factfile)
     else:
         # -----------
         # via CONSOLE


### PR DESCRIPTION
After Juniper/py-junos-eznc#638, PyEZ facts are now a custom object
rather than a true dict. In addition, facts are now read-only.

This was partially addressed in #210, but I missed the case
where the `savedir` option is specified to dump the facts into
JSON files. The same fix is also required in this case.