### PR TITLE
junos_get_table includes the table's key in response

### DIFF
--- a/library/junos_get_table
+++ b/library/junos_get_table
@@ -177,7 +177,7 @@ def juniper_items_to_list_of_dicts(data):
             if normalized_value and not isinstance(normalized_value, (str, list, int, dict)):
                 normalized_value = juniper_items_to_list_of_dicts(normalized_value)
             temp[normalized_key] = normalized_value
-        list_of_resources.append(temp)
+        list_of_resources.append({table_key[0]: temp})
     return list_of_resources
 
 

--- a/library/junos_get_table
+++ b/library/junos_get_table
@@ -177,7 +177,8 @@ def juniper_items_to_list_of_dicts(data):
             if normalized_value and not isinstance(normalized_value, (str, list, int, dict)):
                 normalized_value = juniper_items_to_list_of_dicts(normalized_value)
             temp[normalized_key] = normalized_value
-        list_of_resources.append({table_key[0]: temp})
+        list_of_resources.append({table_key[0] if isinstance(table_key, (tuple))
+                                  else table_key: temp})
     return list_of_resources
 
 


### PR DESCRIPTION
junos_get_table with response_type set to list_of_dicts returns the key of the table within the returned list of dictionaries as well, which is the default behavior of the "juniper_items" mode.

Relates to issue: https://github.com/Juniper/ansible-junos-stdlib/issues/221