### PR TITLE
junos_install_os used to fail without 'logfile' parameter

### DIFF
--- a/library/junos_install_os
+++ b/library/junos_install_os
@@ -180,7 +180,7 @@ def junos_install_os(module, dev):
         def do_log(msg, level='info'):
             getattr(logging, level)(msg)
     else:
-        def do_log(msg):
+        def do_log(msg, level=None):
             pass
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Fix #246 