### PR TITLE
Callback option added to junos_jsnapy to control printing of JSNAPy info and error messages, updated jsnapy callback

### DIFF
--- a/callback_plugins/jsnapy.py
+++ b/callback_plugins/jsnapy.py
@@ -177,7 +177,11 @@ class CallbackModule(CallbackBase):
                             self._display.display( "\t\t'{0}'".format( str(test['message'])),
                               color=C.COLOR_ERROR)
                             # With jsnapy 1.2 err field parsed into message for each failed test
+                        elif 'xpath_error' in test:
+                          if test['xpath_error'] is True:
+                            self._display.display( "\t\tTest execution failed parsing results(XPath)! Check the XML response file.",
+                              color=C.COLOR_ERROR)
                         else:
-                          self._display.display( "\t\tTest failed without providing message.",
+                          self._display.display( "\t\tTest execution failed! Check test definition.",
                             color=C.COLOR_ERROR)
     #self._display.display("Checking for callback value, in '{0}'".format(json.dumps(result)))

--- a/callback_plugins/jsnapy.py
+++ b/callback_plugins/jsnapy.py
@@ -10,7 +10,59 @@ import json
 
 from ansible.plugins.callback import CallbackBase
 from ansible import constants as C
-
+'''
+The JSNAPy result structure is constructed as follows:
+{
+  action: # one of: snap_pre, snap_post, snapcheck, check
+  changed:
+  final_result:
+  msg:
+  passPercentage:
+  router:
+  test_results: {
+    test_rpc_or_cli_used: [
+      {
+        count: {
+          fail: # number of entries in failed[]
+          pass: # number of entries in passed[]
+        }
+        expected_note_value: # value expected of xpath node
+        failed: [  # filled in if a test failed
+                   # Failure can be test test condition was false
+                   # or no valid data to test against.
+          {
+            actual_node_value:
+            id: {} # if set in test definition
+            message: "" # error message templated by test run 
+                    # may be empty if test did not find valid data
+                    # ex. an IS-IS test where IS-IS is not running
+            post: {} # key/value pairs defined in test
+            pre: {} # key/value pairs defined in test 
+          }
+          ... # {} repeated for number of tests that failed 
+        ]
+        node_name: # xpath test searched
+        passed: [ # filled in if a test failed
+          {
+            actual_node_value:
+            id: {} # if set in test definition
+            message: "" # error message templated by test run 
+            post: {} # key/value pairs defined in test
+            pre: {} # key/value pairs defined in test 
+          }
+          ... # {} repeated for number of tests that passed
+        ]
+        result:
+        test_name:
+        testoperation:
+        xpath:
+      }
+      ... # {} repeated for number of times this test executed
+    ]
+    ... # test key/value pair repeated for each test invoked
+  }
+}
+'''
 class CallbackModule(CallbackBase):
   """
   This callback add extra logging for the module junos_jsnapy .
@@ -63,30 +115,69 @@ class CallbackModule(CallbackBase):
     for host, results in self._results.iteritems():
       has_printed_banner = False
       for result in results:
-        # self._pp.pprint(result.__dict__)
+        callback = None
+        # Get the callback from 'invocation' structure.
         res = result._result
-        if res['final_result'] == "Failed":
-          for test_name, test_results in res['test_results'].iteritems():
-            for testlet in test_results:
-              if testlet['count']['fail'] != 0:
-
+        action = ''
+        if 'invocation' in res:
+          if 'module_args' in res['invocation']:
+            if 'callback' in res['invocation']['module_args']:
+              callback = res['invocation']['module_args']['callback']
+            if 'action' in res['invocation']['module_args']:
+              action = res['invocation']['module_args']['action']
+        if action in ['check', 'snapcheck']:
+          if callback is None:
+              # self._pp.pprint(result.__dict__)
+              if res['final_result'] == "Failed":
+                for test_name, test_results in res['test_results'].iteritems():
+                  for testlet in test_results:
+                    if testlet['count']['fail'] != 0:
+  
+                      if not has_printed_banner:
+                        self._display.banner("JSNAPy Results for: " + str(host))
+                        has_printed_banner = True
+  
+                      for test in testlet['failed']:
+  
+                        # Check if POST exist in the response
+                        data = ''
+                        if test.has_key('post'):
+                            data = test['post']
+                        else:
+                            data = test
+  
+                        self._display.display(
+                          "Value of '{0}' not '{1}' at '{2}' with {3}".format(
+                            str(testlet['node_name']),
+                            str(testlet['testoperation']),
+                            str(testlet['xpath']),
+                            json.dumps(data)),
+                          color=C.COLOR_ERROR)
+          else:
+            self._display.banner("Results for: " + str(host), color=C.COLOR_VERBOSE )
+            for test_name, test_results in res['test_results'].iteritems(): # test_name is cmd or rpc
+                has_printed_banner = False
                 if not has_printed_banner:
-                  self._display.banner("JSNAPy Results for: " + str(host))
+                  self._display.display(" -- Test: " + str(test_name))
                   has_printed_banner = True
-
-                for test in testlet['failed']:
-
-                  # Check if POST exist in the response
-                  data = ''
-                  if test.has_key('post'):
-                      data = test['post']
-                  else:
-                      data = test
-
-                  self._display.display(
-                    "Value of '{0}' not '{1}' at '{2}' with {3}".format(
-                      str(testlet['node_name']),
-                      str(testlet['testoperation']),
-                      str(testlet['xpath']),
-                      json.dumps(data)),
-                    color=C.COLOR_ERROR)
+                for testlet in test_results:
+                  if callback == 'info':
+                    self._display.display("\tResults for test: " + str(testlet['test_name']))
+                    if testlet['count']['pass'] != 0:
+                        for test in testlet['passed']:
+                          if test['message'] is not None:
+                            self._display.display( "\t\t'{0}'".format( str(test['message'])))
+                         # With jsnapy 1.2 info field parsed into message for each passed test
+                  if callback == 'error' or callback == 'info':
+                    if testlet['count']['fail'] != 0:
+                      self._display.display("\tErrors for test: " + str(testlet['test_name']))
+                      for test in testlet['failed']:
+                        if 'message' in test:
+                          if test['message'] is not None:
+                            self._display.display( "\t\t'{0}'".format( str(test['message'])),
+                              color=C.COLOR_ERROR)
+                            # With jsnapy 1.2 err field parsed into message for each failed test
+                        else:
+                          self._display.display( "\t\tTest failed without providing message.",
+                            color=C.COLOR_ERROR)
+    #self._display.display("Checking for callback value, in '{0}'".format(json.dumps(result)))

--- a/library/junos_jsnapy
+++ b/library/junos_jsnapy
@@ -50,10 +50,13 @@ description:
       the returned value.
       An experimental Callback_Plugin for junos_jsnapy is available to provide
       additional information about tests that failed.
+      If the callback option is set to "error", the test definition err field 
+      will be printed; if set to "info", both the info and err will be printed.
       To enable it, you need to add "callback_whitelist = jsnapy" in your ansible
       configuration file.
 requirements:
     - junos-eznc >= 1.2.2
+    - JSNAPy >= 1.2.0
 options:
     host:
         description:
@@ -119,6 +122,13 @@ options:
             - The YAML configuration file for the JSNAPy tests
         required: false
         default: None
+    callback:
+        description:
+            - Controls behavior of jsnapy callback function, acceptable values are:
+            - Not set: Original behavior of the callback. Prints node_name, testoperation, and xpath.
+            - error: Prints the templated result of the err field in the JSNAPy test description.
+            - info: Prints the templated result of the err and info fields in the JSNAPy test description.
+
 '''
 
 EXAMPLES = '''
@@ -255,6 +265,8 @@ def jsnap_selection(dev, module):
         config_data = {'tests': test_files_validated}
 
     results = {'action': action}
+    if args['callback'] is not None:
+        results['callback'] = args['callback']
     js = SnapAdmin()
 
     if action == 'snapcheck':
@@ -298,7 +310,8 @@ def main():
                            test_files=dict(required=False, type='list', default=None),
                            config_file=dict(required=False, default=None),
                            dir=dict(required=False, default='/etc/jsnapy/testfiles'),
-                           action=dict(required=True, choices=['check', 'snapcheck', 'snap_pre', 'snap_post'], default=None)
+                           action=dict(required=True, choices=['check', 'snapcheck', 'snap_pre', 'snap_post'], default=None),
+                           callback=dict(required=False, choices=['error', 'info'], default=None)
                            ),
         mutually_exclusive=[['test_files', 'config_file']],
         required_one_of=[['test_files', 'config_file']],


### PR DESCRIPTION
Added 'callback' option to junos_jsnapy to control printing of messages set in jsnapy test.
Added code in jsnapy.py to print test info and error messages contained in test
results structure. Whether error and/or info messages are printed is
controlled by the module option 'callback'.