### PR TITLE
Only require libraries if they are actually needed by a module. Fixes #301.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM juniper/pyez:latest
 MAINTAINER Stephen Steiner <ssteiner@juniper.net>
 
 ARG ver_ansible=2.4.0.0
-ARG ver_jsnapy=1.1.0
+ARG ver_jsnapy=1.2.1
 
 WORKDIR /tmp
 RUN mkdir /tmp/ansible-junos-stdlib &&\

--- a/library/juniper_junos_command.py
+++ b/library/juniper_junos_command.py
@@ -397,7 +397,8 @@ def main():
         # supported. Well, that's not completely true. It does depend on the
         # command executed. See the I(changed) key in the RETURN documentation
         # for more details.
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_jxmlease_version=juniper_junos_common.MIN_JXMLEASE_VERSION,
     )
 
     # Check over commands

--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -853,7 +853,8 @@ def main():
         # Required together options.
         required_together=[['template', 'vars']],
         # Check mode is implemented.
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_jxmlease_version=juniper_junos_common.MIN_JXMLEASE_VERSION,
     )
     # Do additional argument verification.
 

--- a/library/juniper_junos_facts.py
+++ b/library/juniper_junos_facts.py
@@ -326,7 +326,8 @@ def main():
         # Since this module doesn't change the device's configuration, there is
         # no additional work required to support check mode. It's inherently
         # supported.
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_jxmlease_version=juniper_junos_common.MIN_JXMLEASE_VERSION,
     )
 
     junos_module.logger.debug("Gathering facts.")

--- a/library/juniper_junos_jsnapy.py
+++ b/library/juniper_junos_jsnapy.py
@@ -293,7 +293,8 @@ def main():
         mutually_exclusive=[['test_files', 'config_file']],
         # One of test_files or config_file is required.
         required_one_of=[['test_files', 'config_file']],
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_jsnapy_version=juniper_junos_common.MIN_JSNAPY_VERSION,
     )
 
     # Straight from params

--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -469,7 +469,8 @@ def main():
         # supported. Well, that's not completely true. It does depend on the
         # RPC executed. See the I(changed) key in the RETURN documentation
         # for more details.
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_jxmlease_version=juniper_junos_common.MIN_JXMLEASE_VERSION,
     )
 
     # Check over rpcs

--- a/library/juniper_junos_table.py
+++ b/library/juniper_junos_table.py
@@ -399,7 +399,8 @@ def main():
                                default='list_of_dicts'),
         ),
         # Check mode is implemented.
-        supports_check_mode=True
+        supports_check_mode=True,
+        min_yaml_version=juniper_junos_common.MIN_YAML_VERSION,
     )
 
     # Straight from params

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 junos-eznc>=2.1.7
-jsnapy>=1.1.0
+jsnapy>=1.2.1
 jxmlease>=1.0.1
 lxml>3.2.4
 yaml>=3.08


### PR DESCRIPTION
- Also bump required JSNAPy version to the new 1.2.1.
- Update/correct some documentation in the common module.
- Reorganize order of methods in the common module.

