### PR TITLE
Mimic old behavior for junos_install_config with check_commit = False.

### DIFF
--- a/action_plugins/_junos_install_config.py
+++ b/action_plugins/_junos_install_config.py
@@ -78,6 +78,19 @@ class ActionModule(juniper_junos_common.JuniperJunosActionModule):
         # Always commit changes to mimic the previous behavior
         self._task.args['commit_empty_changes'] = True
 
+        # If check_commit is False, then also bypass the commit.
+        check = True
+        # Check for the 'check_commit' option which was an optional boolean
+        # argument for the junos_install_config module.
+        if 'check_commit' in self._task.args:
+            check = self._task.args.pop('check_commit')
+        if check is not None and self.convert_to_bool(check) is False:
+            # Translate to check_commit = False, commit = False, and
+            # commit_empty_changes = False
+            self._task.args['check_commit'] = False
+            self._task.args['commit'] = False
+            self._task.args['commit_empty_changes'] = False
+
         # Remaining arguments can be passed through transparently.
 
         # Call the parent action module.


### PR DESCRIPTION
There was a backwards compatibility issue with `junos_install_config`.
```
junos_install_config:
   check_commit: false
```
In 1.4.3, the above used to perform a diff, but not perform a "commit check"
or a "commit". Now, it performs the diff, but it also does a "commit".

This change restores the 1.4.3 behavior where:
```
junos_install_config:
   check_commit: false
```
will only perform the diff and not perform a "commit".