### PR TITLE
Fix acceptable_percent_loss parameter to juniper_junos_ping.

### DIFF
--- a/library/juniper_junos_ping.py
+++ b/library/juniper_junos_ping.py
@@ -521,7 +521,7 @@ def main():
     # Results should include all the ping params in argument_spec_keys.
     for key in argument_spec_keys:
         results[key] = params.get(key)
-    # Overrite to be a string in the results
+    # Overwrite to be a string in the results
     results['acceptable_percent_loss'] = str(
         params.get('acceptable_percent_loss'))
     # Add timeout to the response even though it's a connect parameter.
@@ -534,7 +534,7 @@ def main():
     # Execute the ping.
     results = junos_module.ping(
                   ping_params,
-                  acceptable_percent_loss=['acceptable_percent_loss'],
+                  acceptable_percent_loss=params['acceptable_percent_loss'],
                   results=results)
 
     # Return results.


### PR DESCRIPTION
The `acceptable_percent_loss` parameter to `juniper_junos_ping` was not being correctly interpreted. This led to the module incorrectly returning a pass even when it should have failed because the `acceptable_percent_loss` was exceeded.