### PR TITLE
Correcting wrong usage of iteritems()

### DIFF
--- a/callback_plugins/jsnapy.py
+++ b/callback_plugins/jsnapy.py
@@ -53,7 +53,7 @@ class CallbackModule(CallbackBase):
 
       ## Check if dict entry already exist for this host
       host = result._host.name
-      if not host in list(self._results.keys()):
+      if not host in self._results.keys():
         self._results[host] = []
 
       self._results[host].append(result)

--- a/docs/ansible2rst.py
+++ b/docs/ansible2rst.py
@@ -216,7 +216,7 @@ def add_fragments(doc, filename):
         if 'options' not in fragment and 'logging_options' not in fragment and 'connection_options' not in fragment:
             raise Exception("missing options in fragment (%s), possibly misformatted?: %s" % (fragment_name, filename))
 
-        for key, value in iteritems(fragment.items()):
+        for key, value in iteritems(fragment):
             if key in doc:
                 # assumes both structures have same type
                 if isinstance(doc[key], MutableMapping):

--- a/library/juniper_junos_table.py
+++ b/library/juniper_junos_table.py
@@ -37,7 +37,6 @@
 #
 
 from __future__ import absolute_import, division, print_function
-from six import iteritems
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community',
@@ -339,7 +338,7 @@ def expand_items(module, data):
     """
     resources = []
     # data.items() is a list of tuples
-    for table_key, table_fields in iteritems(data):
+    for table_key, table_fields in data.items():
         # sample:
         # ('fxp0', [('neighbor_interface', '1'), ('local_interface', 'fxp0'),
         # ('neighbor', 'vmx2')]
@@ -360,7 +359,7 @@ def juniper_items_to_list_of_dicts(module, data):
     """
     resources = []
     # data.items() is a list of tuples
-    for table_key, table_fields in iteritems(data):
+    for table_key, table_fields in data.items():
         # sample:
         # ('fxp0', [('neighbor_interface', '1'), ('local_interface', 'fxp0'),
         # ('neighbor', 'vmx2')]

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -664,7 +664,7 @@ class JuniperJunosModule(AnsibleModule):
             self.params.pop(arg_name)
         # Promote any provider arg_name into params
         if 'provider' in self.params and self.params['provider'] is not None:
-            for arg_name, arg_value in iteritems(self.params['provider']):
+            for arg_name, arg_value in self.params['provider'].items():
                 if arg_name in self.aliases:
                     arg_name = self.aliases[arg_name]
                 self.params[arg_name] = arg_value


### PR DESCRIPTION
iteritems() gives an error in _junos_table as type of variable "data" is not a dictionary, rather it is a PyEZ factory table object which has a custom items() method defined.

Changing back iteritems(data) to data.items()