### PR TITLE
Add support for defining ssh_config path

### DIFF
--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -289,6 +289,13 @@ class ModuleDocFragment(object):
         type: path
         aliases:
           - ssh_keyfile
+      ssh_config:
+        description:
+          - The path to the SSH client configuration file. If this option is not
+            specified, then the PyEZ Device instance by default queries file
+            ~/.ssh/config.
+        required: false
+        type: path
       timeout:
         description:
           - The maximum number of seconds to wait for RPC responses from the

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -443,6 +443,9 @@ connection_spec = {
                                  # Default behavior coded in
                                  # JuniperJunosActionModule.run()
                                  default=None),
+    'ssh_config': dict(type='path',
+                                 required=False,
+                                 default=None),
     'mode': dict(choices=[None, 'telnet', 'serial'],
                  default=None),
     'console': dict(type='str',


### PR DESCRIPTION
juniper_junos_common.py does not support user defined path for SSH configuration, so by default ~/.ssh/config is used by PyEZ. With this trivial patch one can define alternative ssh_config file, for example /etc/ssh/ssh_config that is then further passed to PyEZ.