### PR TITLE
Module utils ansiballz integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ dist: trusty
 env:
   - ANSIBLE_VERSION=2.4.0.0
   - ANSIBLE_VERSION=2.3.0.0
-  - ANSIBLE_VERSION=2.2.0.0
-  - ANSIBLE_VERSION=2.1.3.0
 
 install:
 ## Create Docker with Ansible modules and all dependancies

--- a/library/juniper_junos_command.py
+++ b/library/juniper_junos_command.py
@@ -308,7 +308,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_command.py
+++ b/library/juniper_junos_command.py
@@ -303,58 +303,16 @@ stdout_lines:
 import sys
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     # Create the module instance.
     junos_module = juniper_junos_common.JuniperJunosModule(
         argument_spec=dict(

--- a/library/juniper_junos_command.py
+++ b/library/juniper_junos_command.py
@@ -308,6 +308,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -737,6 +737,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -732,58 +732,16 @@ msg:
 import time
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     # Choices which are defined in the common module.
     config_format_choices = juniper_junos_common.CONFIG_FORMAT_CHOICES
     config_database_choices = [None] + \

--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -737,7 +737,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_facts.py
+++ b/library/juniper_junos_facts.py
@@ -176,6 +176,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_facts.py
+++ b/library/juniper_junos_facts.py
@@ -171,52 +171,13 @@ import os.path
 
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def get_facts_dict(junos_module):
@@ -319,9 +280,6 @@ def save_inventory(junos_module, inventory):
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     config_format_choices = [None]
     config_format_choices += juniper_junos_common.CONFIG_FORMAT_CHOICES
 

--- a/library/juniper_junos_facts.py
+++ b/library/juniper_junos_facts.py
@@ -176,7 +176,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_jsnapy.py
+++ b/library/juniper_junos_jsnapy.py
@@ -208,6 +208,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 def main():

--- a/library/juniper_junos_jsnapy.py
+++ b/library/juniper_junos_jsnapy.py
@@ -203,59 +203,16 @@ msg:
 import os.path
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
-
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 def main():
     JSNAPY_ACTION_CHOICES = ['check', 'snapcheck', 'snap_pre', 'snap_post']
-
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
 
     # Create the module instance.
     junos_module = juniper_junos_common.JuniperJunosModule(

--- a/library/juniper_junos_jsnapy.py
+++ b/library/juniper_junos_jsnapy.py
@@ -208,7 +208,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 def main():

--- a/library/juniper_junos_ping.py
+++ b/library/juniper_junos_ping.py
@@ -385,7 +385,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_ping.py
+++ b/library/juniper_junos_ping.py
@@ -385,6 +385,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_ping.py
+++ b/library/juniper_junos_ping.py
@@ -380,58 +380,16 @@ warnings:
 '''
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     # The argument spec for the module.
     argument_spec = dict(
         dest=dict(type='str',

--- a/library/juniper_junos_pmtud.py
+++ b/library/juniper_junos_pmtud.py
@@ -242,52 +242,13 @@ warnings:
 '''
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def main():
@@ -308,9 +269,6 @@ def main():
 
     # Choices for max_size
     MAX_SIZE_CHOICES = [0] + list(map(lambda x: 2 ** x, range(1, 17)))
-
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
 
     # Create the module instance.
     junos_module = juniper_junos_common.JuniperJunosModule(

--- a/library/juniper_junos_pmtud.py
+++ b/library/juniper_junos_pmtud.py
@@ -247,6 +247,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_pmtud.py
+++ b/library/juniper_junos_pmtud.py
@@ -247,7 +247,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -375,7 +375,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -370,58 +370,16 @@ except NameError:
     basestring = str
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     # Create the module instance.
     junos_module = juniper_junos_common.JuniperJunosModule(
         argument_spec=dict(

--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -375,6 +375,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_software.py
+++ b/library/juniper_junos_software.py
@@ -378,52 +378,13 @@ except ImportError:
     from urlparse import urlparse
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def parse_version_from_filename(filename):
@@ -476,9 +437,6 @@ def define_progress_callback(junos_module):
 
 def main():
     CHECKSUM_ALGORITHM_CHOICES = ['md5', 'sha1', 'sha256']
-
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
 
     #Define the argument spec.
     software_argument_spec=dict(

--- a/library/juniper_junos_software.py
+++ b/library/juniper_junos_software.py
@@ -383,6 +383,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_software.py
+++ b/library/juniper_junos_software.py
@@ -383,7 +383,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_srx_cluster.py
+++ b/library/juniper_junos_srx_cluster.py
@@ -149,7 +149,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_srx_cluster.py
+++ b/library/juniper_junos_srx_cluster.py
@@ -144,58 +144,16 @@ reboot:
 # Standard library imports
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     # Create the module instance.
     junos_module = juniper_junos_common.JuniperJunosModule(
         argument_spec=dict(

--- a/library/juniper_junos_srx_cluster.py
+++ b/library/juniper_junos_srx_cluster.py
@@ -149,6 +149,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_system.py
+++ b/library/juniper_junos_system.py
@@ -244,58 +244,16 @@ other_re:
 '''
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     # Create the module instance.
     junos_module = juniper_junos_common.JuniperJunosModule(
         argument_spec=dict(

--- a/library/juniper_junos_system.py
+++ b/library/juniper_junos_system.py
@@ -249,7 +249,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_system.py
+++ b/library/juniper_junos_system.py
@@ -249,6 +249,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_table.py
+++ b/library/juniper_junos_table.py
@@ -291,6 +291,7 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_table.py
+++ b/library/juniper_junos_table.py
@@ -291,7 +291,6 @@ But custom module_utils directory is supported from Ansible 2.3
 Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
 # Ansiballz packages module_utils into ansible.module_utils
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils import juniper_junos_common
 
 

--- a/library/juniper_junos_table.py
+++ b/library/juniper_junos_table.py
@@ -286,52 +286,13 @@ import os.path
 RESPONSE_CHOICES = ['list_of_dicts', 'juniper_items']
 
 
-def import_juniper_junos_common():
-    """Imports the juniper_junos_common module from _module_utils_path.
+"""From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules
+But custom module_utils directory is supported from Ansible 2.3
+Reference for the issue: https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw """
 
-    Ansible versions < 2.4 do not provide a way to package common code in a
-    role. This function solves that problem for juniper_junos_* modules by
-    reading the module arguments passed on stdin and interpreting the special
-    option _module_utils_path as a path to the the directory where the
-    juniper_junos_common module resides. It temporarily inserts this path at
-    the head of sys.path, imports the juniper_junos_common module, and removes
-    the path from sys.path. It then returns the imported juniper_junos_common
-    module object. All juniper_junos_* modules must include this boilerplate
-    function in order to import the shared juniper_junos_common module.
-
-    Args:
-        None.
-
-    Returns:
-        The juniper_junos_common module object.
-
-    Raises:
-        ImportError: If the juniper_junos_common object can not be imported
-                     from the path specified by the module_utils_path argument.
-    """
-    from ansible.module_utils.basic import AnsibleModule
-    import sys
-
-    juniper_junos_common = None
-    module = AnsibleModule(
-        argument_spec={
-            '_module_utils_path': dict(type='path', default=None),
-            # Avoids a warning about not specifying no_log for passwd.
-            'passwd': dict(no_log=True)
-        },
-        # Doesn't really work due to Ansible bug. Keeping it here for when
-        # Ansible bug is fixed.
-        no_log=True,
-        check_invalid_arguments=False,
-        bypass_checks=True,
-        supports_check_mode=True
-    )
-    import_path = module.params.get('_module_utils_path')
-    if import_path is not None:
-        sys.path.insert(0, import_path)
-        import juniper_junos_common
-        del sys.path[0]
-    return juniper_junos_common
+# Ansiballz packages module_utils into ansible.module_utils
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import juniper_junos_common
 
 
 def expand_items(module, data):
@@ -376,9 +337,6 @@ def juniper_items_to_list_of_dicts(module, data):
 
 
 def main():
-    # Import juniper_junos_common
-    juniper_junos_common = import_juniper_junos_common()
-
     # Create the module instance.
     junos_module = juniper_junos_common.JuniperJunosModule(
         argument_spec=dict(

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -501,7 +501,7 @@ logging_spec = {
 }
 
 # The logdir and logfile options are mutually exclusive.
-logging_spec_mutually_exclusive = ['logfile', 'logdir']
+logging_spec_mutually_exclusive = [['logfile', 'logdir']]
 
 # Other logging names which should be logged to the logfile
 additional_logger_names = ['ncclient', 'paramiko']
@@ -653,6 +653,8 @@ class JuniperJunosModule(AnsibleModule):
         argument_spec.update(top_spec)
         # Extend mutually_exclusive with connection_mutually_exclusive
         mutually_exclusive += top_spec_mutually_exclusive
+        from ansible.errors import AnsibleError
+        #raise AnsibleError(mutually_exclusive)
         # Call parent's __init__()
         super(JuniperJunosModule, self).__init__(
             argument_spec=argument_spec,

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -501,7 +501,7 @@ logging_spec = {
 }
 
 # The logdir and logfile options are mutually exclusive.
-logging_spec_mutually_exclusive = [['logfile', 'logdir']]
+logging_spec_mutually_exclusive = ['logfile', 'logdir']
 
 # Other logging names which should be logged to the logfile
 additional_logger_names = ['ncclient', 'paramiko']
@@ -653,8 +653,6 @@ class JuniperJunosModule(AnsibleModule):
         argument_spec.update(top_spec)
         # Extend mutually_exclusive with connection_mutually_exclusive
         mutually_exclusive += top_spec_mutually_exclusive
-        from ansible.errors import AnsibleError
-        #raise AnsibleError(mutually_exclusive)
         # Call parent's __init__()
         super(JuniperJunosModule, self).__init__(
             argument_spec=argument_spec,


### PR DESCRIPTION
From Ansible 2.1, Ansible uses Ansiballz framework for assembling modules,
But custom module_utils directory is supported from Ansible 2.3 .
Please find the reference for the issue [here](https://groups.google.com/forum/#!topic/ansible-project/J8FL7Z1J1Mw)

Ansiballz packages modules_utils under ansible.module_utils, so juniper_junos_common can be imported by using -
`from ansible.module_utils import juniper_junos_common`