### PR TITLE
Handle empty `version_info` and `junos_info` facts more gracefully. Addresses #360.

### DIFF
--- a/library/juniper_junos_facts.py
+++ b/library/juniper_junos_facts.py
@@ -246,11 +246,11 @@ def get_facts_dict(junos_module):
         del facts['2RE']
     # The value of the 'version_info' key is a custom junos.version_info
     # object. Convert this value to a dict.
-    if 'version_info' in facts:
+    if 'version_info' in facts and facts['version_info'] is not None:
         facts['version_info'] = dict(facts['version_info'])
     # The values of the ['junos_info'][re_name]['object'] keys are
     # custom junos.version_info objects. Convert all of these to dicts.
-    if 'junos_info' in facts:
+    if 'junos_info' in facts and facts['junos_info'] is not None:
         for key in facts['junos_info']:
             facts['junos_info'][key]['object'] = dict(
                 facts['junos_info'][key]['object'])


### PR DESCRIPTION
When PyEZ is unable to gather a fact from a Junos device, the key still exists
in the dev.facts attribute, but has a value of None. The checks for converting
the `version_info` and `junos_info` facts from their custom types to a dict
did not properly account for this situation. IN that case, they would attempt
to convert `None` to a `dict` and throw an exception.

This PR more gracefully handles that situation. However, it does not fix the
underlying Junos or PyEZ issue which might lead to being unable to collect
the `version_info` and `junos_info` facts from a device. That would need
to be addresses separately in PyEZ.