### PR TITLE
Create ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,55 @@
+<!---
+Verify first that your issue/request is not already reported on GitHub. -->
+
+Issue Type
+------
+<!--- Pick one below and delete the rest -->
+ - Bug Report
+ - Feature Idea
+ - Documentation Report
+
+Module Name
+------
+<!--- Insert, BELOW THIS COMMENT, the name of the module, plugin, task or feature
+-->
+
+Juniper.Junos role and Python libraries version
+<!--- Paste, BELOW THIS COMMENT, verbatim output from "ansible --version" and  "pip freeze" between quotes below 
+Also provide the version of Juniper.junos role-->
+```
+
+```
+
+OS / Environment
+------
+<!--- Mention, the JUNOS version and firmware model you are trying to control-->
+
+Summary
+------
+<!--- Explain the problem briefly -->
+
+Steps to reproduce
+------
+<!--- For bugs, show exactly how to reproduce the problem, using a minimal test-case.
+For new features, show how the feature would be used. -->
+
+<!--- Paste example playbooks or commands between quotes below -->
+```yaml
+
+```
+
+<!--- You can also paste gist.github.com links for larger files -->
+
+Expected results
+<!--- What did you expect to happen when running the steps above? -->
+```
+
+```
+Actual results
+------
+<!--- What actually happened? If possible run with extra verbosity (-vvvv) -->
+
+<!--- Paste verbatim command output between quotes below -->
+```
+
+```


### PR DESCRIPTION
- To help user mention all the required details needed for contributor to respond to the issue.
- To help contributor get the details straight right from the start.

The issue template has been referenced from Ansible's issue template.
Please find the reference [here](https://github.com/ansible/ansible/blob/devel/.github/ISSUE_TEMPLATE.md)