### PR TITLE
Fixed juniper_junos_rpc error in Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ script:
   - docker run -t -i -v $(pwd):/project juniper/pyez-ansible:travis ansible-playbook -i ravello.ini pb.junos_ping.yaml
   - docker run -t -i -v $(pwd):/project juniper/pyez-ansible:travis ansible-playbook -i ravello.ini pb.junos_pmtud.yaml
   - docker run -t -i -v $(pwd):/project juniper/pyez-ansible:travis ansible-playbook -i ravello.ini pb.junos_jsnapy.yaml
+  - docker run -t -i -v $(pwd):/project juniper/pyez-ansible:travis ansible-playbook -i ravello.ini pb.junos_rpc.yaml

--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -569,7 +569,7 @@ def main():
                 text_output = resp.text
                 junos_module.logger.debug('Text output set.')
             elif format == 'xml':
-                text_output = junos_module.etree.tostring(resp,
+                text_output = junos_module.etree.tostring(resp, encoding="unicode",
                                                           pretty_print=True)
                 parsed_output = junos_module.jxmlease.parse_etree(resp)
                 junos_module.logger.debug('XML output set.')

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -510,7 +510,7 @@ connection_spec_mutually_exclusive = [['mode', 'console'],
 # Keys are connection options. Values are a list of task_vars to use as the
 # default value.
 connection_spec_fallbacks = {
-    'host': ['inventory_hostname', 'ansible_host'],
+    'host': ['ansible_host', 'inventory_hostname'],
     'user': ['ansible_connection_user', 'ansible_ssh_user', 'ansible_user'],
     'passwd': ['ansible_ssh_pass', 'ansible_pass'],
     'port': ['ansible_ssh_port', 'ansible_port'],

--- a/tests/pb.junos_rpc.yaml
+++ b/tests/pb.junos_rpc.yaml
@@ -12,6 +12,10 @@
 ##################################################
     - name: "Execute single RPC get-software-information without any kwargs"
       juniper_junos_rpc:
+        host: "{{ ansible_ssh_host }}"
+        port: "{{ ansible_ssh_port }}"
+        user: "{{ ansible_ssh_user }}"
+        passwd: "{{ ansible_ssh_pass }}"
         rpcs:
           - "get-software-information"
       register: test1
@@ -29,7 +33,10 @@
 ##################################################
     - name: "Get Device Configuration with dest"
       juniper_junos_rpc:
-        host: "{{ inventory_hostname }}"
+        host: "{{ ansible_ssh_host }}"
+        port: "{{ ansible_ssh_port }}"
+        user: "{{ ansible_ssh_user }}"
+        passwd: "{{ ansible_ssh_pass }}"
         rpc: get-config
         dest: get_config.conf
       register: test2
@@ -52,7 +59,10 @@
 
     - name: "Get Device Configuration in xml"
       juniper_junos_rpc:
-        host: "{{ inventory_hostname }}"
+        host: "{{ ansible_ssh_host }}"
+        port: "{{ ansible_ssh_port }}"
+        user: "{{ ansible_ssh_user }}"
+        passwd: "{{ ansible_ssh_pass }}"
         rpc: get-interface-information
         kwargs: "interface_name=em0"
         format: text
@@ -70,6 +80,10 @@
 
     - name: "Execute multiple RPCs without any kwargs"
       juniper_junos_rpc:
+        host: "{{ ansible_ssh_host }}"
+        port: "{{ ansible_ssh_port }}"
+        user: "{{ ansible_ssh_user }}"
+        passwd: "{{ ansible_ssh_pass }}"
         rpcs:
           - "get-software-information"
           - "get-interface-information"
@@ -87,6 +101,10 @@
 
     - name: "Execute multiple RPCs with multiple kwargs"
       juniper_junos_rpc:
+        host: "{{ ansible_ssh_host }}"
+        port: "{{ ansible_ssh_port }}"
+        user: "{{ ansible_ssh_user }}"
+        passwd: "{{ ansible_ssh_pass }}"
         rpcs:
           - "get-software-information"
           - "get-interface-information"
@@ -107,6 +125,10 @@
 
     - name: "Execute multiple RPCs with multiple kwargs and dest-dir"
       juniper_junos_rpc:
+        host: "{{ ansible_ssh_host }}"
+        port: "{{ ansible_ssh_port }}"
+        user: "{{ ansible_ssh_user }}"
+        passwd: "{{ ansible_ssh_pass }}"
         rpcs:
           - "get-software-information"
           - "get-interface-information"
@@ -134,6 +156,10 @@
 
     - name: Get Device Configuration for interface
       juniper_junos_rpc:
+        host: "{{ ansible_ssh_host }}"
+        port: "{{ ansible_ssh_port }}"
+        user: "{{ ansible_ssh_user }}"
+        passwd: "{{ ansible_ssh_pass }}"
         host: "{{ inventory_hostname }}"
         rpc: get-config
         filter_xml: "<configuration><interfaces/></configuration>"

--- a/tests/pb.junos_rpc.yaml
+++ b/tests/pb.junos_rpc.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Test junos_rpc module
-  hosts: VMX
+  hosts: all
   connection: local
   gather_facts: no
   roles:

--- a/tests/pb.junos_rpc.yaml
+++ b/tests/pb.junos_rpc.yaml
@@ -122,6 +122,10 @@
       tags: [ test5 ]
 
 #################
+    - name: Creates directory
+      file:
+        path: out
+        state: directory
 
     - name: "Execute multiple RPCs with multiple kwargs and dest-dir"
       juniper_junos_rpc:

--- a/tests/pb.junos_rpc.yaml
+++ b/tests/pb.junos_rpc.yaml
@@ -1,0 +1,150 @@
+---
+- name: Test junos_rpc module
+  hosts: VMX
+  connection: local
+  gather_facts: no
+  roles:
+    - Juniper.junos
+
+  tasks:
+##################################################
+####    TEST 1                                  ##
+##################################################
+    - name: "Execute single RPC get-software-information without any kwargs"
+      juniper_junos_rpc:
+        rpcs:
+          - "get-software-information"
+      register: test1
+      ignore_errors: True
+      tags: [ test1 ]
+
+    - name: Check TEST 1
+      assert:
+        that:
+          - test1|succeeded
+      tags: [ test1 ]
+
+##################################################
+####    TEST 2                                  ##
+##################################################
+    - name: "Get Device Configuration with dest"
+      juniper_junos_rpc:
+        host: "{{ inventory_hostname }}"
+        rpc: get-config
+        dest: get_config.conf
+      register: test2
+      ignore_errors: True
+      tags: [ test2 ]
+
+    - name: Check that the get_config.conf exists
+      stat:
+        path: get_config.conf
+      register: stat_result
+
+    - name: Check TEST 2
+      assert:
+        that:
+          - test2|succeeded
+          - stat_result.stat.exists == True
+      tags: [ test2 ]
+
+#################
+
+    - name: "Get Device Configuration in xml"
+      juniper_junos_rpc:
+        host: "{{ inventory_hostname }}"
+        rpc: get-interface-information
+        kwargs: "interface_name=em0"
+        format: text
+      register: test3
+      ignore_errors: True
+      tags: [ test3 ]
+
+    - name: Check TEST 3
+      assert:
+        that:
+          - test3|succeeded
+      tags: [ test3 ]
+
+#################
+
+    - name: "Execute multiple RPCs without any kwargs"
+      juniper_junos_rpc:
+        rpcs:
+          - "get-software-information"
+          - "get-interface-information"
+      register: test4
+      ignore_errors: True
+      tags: [ test4 ]
+
+    - name: Check TEST 4
+      assert:
+        that:
+          - test4|succeeded
+      tags: [ test4 ]
+
+#################
+
+    - name: "Execute multiple RPCs with multiple kwargs"
+      juniper_junos_rpc:
+        rpcs:
+          - "get-software-information"
+          - "get-interface-information"
+        kwargs:
+          - {}
+          - "interface_name=em0"
+      register: test5
+      ignore_errors: True
+      tags: [ test5 ]
+
+    - name: Check TEST 5
+      assert:
+        that:
+          - test5|succeeded
+      tags: [ test5 ]
+
+#################
+
+    - name: "Execute multiple RPCs with multiple kwargs and dest-dir"
+      juniper_junos_rpc:
+        rpcs:
+          - "get-software-information"
+          - "get-interface-information"
+        kwargs:
+          - {}
+          - "interface_name=em0"
+        dest_dir: "out"
+      register: test6
+      ignore_errors: True
+      tags: [ test6 ]
+
+    - name: Check that the get_config.conf exists
+      stat:
+        path: out
+      register: stat_result_1
+
+    - name: Check TEST 6
+      assert:
+        that:
+          - test6|succeeded
+          - stat_result_1.stat.exists == True
+      tags: [ test6 ]
+
+#################
+
+    - name: Get Device Configuration for interface
+      juniper_junos_rpc:
+        host: "{{ inventory_hostname }}"
+        rpc: get-config
+        filter_xml: "<configuration><interfaces/></configuration>"
+      register: test7
+      ignore_errors: True
+      tags: [ test7 ]
+
+    - name: Check TEST 7
+      assert:
+        that:
+          - test7|succeeded
+      tags: [ test7 ]
+
+#################

--- a/tests/pb.junos_rpc.yaml
+++ b/tests/pb.junos_rpc.yaml
@@ -57,7 +57,7 @@
 
 #################
 
-    - name: "Get Device Configuration in xml"
+    - name: "Get Device Configuration in text"
       juniper_junos_rpc:
         host: "{{ ansible_ssh_host }}"
         port: "{{ ansible_ssh_port }}"
@@ -164,7 +164,6 @@
         port: "{{ ansible_ssh_port }}"
         user: "{{ ansible_ssh_user }}"
         passwd: "{{ ansible_ssh_pass }}"
-        host: "{{ inventory_hostname }}"
         rpc: get-config
         filter_xml: "<configuration><interfaces/></configuration>"
       register: test7


### PR DESCRIPTION
- On mentioning dest_dir for juniper_junos_rpc in Python 3 raises a TypeError, as in Python 3 strings are encoded as bytes. Fix: Add encoding schema while converting lxme.etree to string
- Added integration tests for juniper_junos_rpc for avoiding such errors in the future.