### PR TITLE
Change hardcoded /usr/bin/python 

### DIFF
--- a/library/juniper_junos_command.py
+++ b/library/juniper_junos_command.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_facts.py
+++ b/library/juniper_junos_facts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_jsnapy.py
+++ b/library/juniper_junos_jsnapy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_ping.py
+++ b/library/juniper_junos_ping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_pmtud.py
+++ b/library/juniper_junos_pmtud.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_software.py
+++ b/library/juniper_junos_software.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_srx_cluster.py
+++ b/library/juniper_junos_srx_cluster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_system.py
+++ b/library/juniper_junos_system.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 1999-2018, Juniper Networks Inc.

--- a/library/juniper_junos_table.py
+++ b/library/juniper_junos_table.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 # Copyright 2016 Jason Edelman <jason@networktocode.com>


### PR DESCRIPTION
to /usr/bin/env python to support virtualenv. It is really irritating to have to specify an ansible_python_interpreter when this is just build into your OS by default.

Ansible does the same: https://github.com/ansible/ansible/blob/devel/bin/ansible#L1

Addresses #322