### PR TITLE
--diff is not working correctly

### DIFF
--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -1054,12 +1054,12 @@ def main():
     junos_module.logger.debug("Step 4 - Determine differences between the "
                               "candidate and committed configuration "
                               "databases.")
-    if diff is True:
+    if diff is True or junos_module._diff:
         diff = junos_module.diff_configuration()
         if diff is not None:
             results['changed'] = True
-            if return_output is True:
-                results['diff'] = diff
+            if return_output is True or junos_module._diff:
+                results['diff'] = {'prepared': diff}
                 results['diff_lines'] = diff.splitlines()
             # Save the diff output
             junos_module.save_text_output('diff', 'diff', diff)


### PR DESCRIPTION
--diff doesn't show the diff as expected.
we changed the handling for the `juniper_junos_config` a bit to return the diff correctly, so that ansible is showing it.

output before the fix:
```
ansible-playbook sitegroups/bgp-router.yml -l XYZ -CD

PLAY [provision bgp-routers] *************************************

TASK [bgp-router : install system configuration] *************************************

changed: [XYZ]

PLAY RECAP *************************************
XYZ            : ok=4    changed=1    unreachable=0    failed=0
```

output after the change:
```
ansible-playbook sitegroups/bgp-router.yml -l XYZ -CD

PLAY [provision bgp-routers] *************************************

TASK [bgp-router : install system configuration] *************************************

[edit system root-authentication]
-   encrypted-password "asdfasdfasdf."; ## SECRET-DATA
+   encrypted-password "ddddddddd."; ## SECRET-DATA
changed: [XYZ]

PLAY RECAP *************************************
XYZ           : ok=4    changed=1    unreachable=0    failed=0
```