### PR TITLE
Add support for ignore_warning in juniper_junos_common/open_configuration

### DIFF
--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -1001,7 +1001,7 @@ def main():
 
     junos_module.logger.debug("Step 1 - Open a candidate configuration "
                               "database.")
-    junos_module.open_configuration(mode=config_mode)
+    junos_module.open_configuration(mode=config_mode, ignore_warning=ignore_warning)
     results['msg'] += 'opened'
 
     junos_module.logger.debug("Step 2 - Load configuration data into the "

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -1344,7 +1344,7 @@ class JuniperJunosModule(AnsibleModule):
         """
         self.sw = jnpr.junos.utils.sw.SW(self.dev)
 
-    def open_configuration(self, mode):
+    def open_configuration(self, mode, ignore_warning=None):
         """Open candidate configuration database in exclusive or private mode.
 
         Failures:
@@ -1352,6 +1352,18 @@ class JuniperJunosModule(AnsibleModule):
             - RpcError: When there's a RPC problem including an already locked
                         config or an already opened private config.
         """
+
+        ignore_warn=['uncommitted changes will be discarded on exit']
+        # if ignore_warning is a bool, pass the bool
+        # if ignore_warning is a string add to the list
+        # if ignore_warning is a list, merge them
+        if ignore_warning != None and isinstance(ignore_warning, bool):
+            ignore_warn = ignore_warning
+        elif ignore_warning != None and isinstance(ignore_warning, str):
+            ignore_warn.append(ignore_warning)
+        elif ignore_warning != None and isinstance(ignore_warning, list):
+            ignore_warn = ignore_warn + ignore_warning
+
         # Already have an open configuration?
         if self.config is None:
             if mode not in CONFIG_MODE_CHOICES:
@@ -1365,8 +1377,7 @@ class JuniperJunosModule(AnsibleModule):
                 elif config.mode == 'private':
                     self.dev.rpc.open_configuration(
                         private=True,
-                        ignore_warning='uncommitted changes will be '
-                                       'discarded on exit')
+                        ignore_warning=ignore_warn)
             except (pyez_exception.ConnectError,
                     pyez_exception.RpcError) as ex:
                 self.fail_json(msg='Unable to open the configuration in %s '


### PR DESCRIPTION
I noticed that `juniper_junos_common/open_configuration` wasn't respecting the `ignore_warning` parameter.

In our environment we were getting some error when 2 tasks are trying to run a config diff + check at the same time (even in private mode)
```
fatal: [rs1-aw38-c1-ash1 -> localhost]: FAILED! => changed=false
  msg: |-
    Unable to open the configuration in private mode: RpcError(severity: warning, bad_element: None, message: warning: changes cannot be committed while 'configure exclusive' is active
    warning: uncommitted changes will be discarded on exit)
```
Here is the task
```yaml
     juniper_junos_config:
        retrieve: candidate
        load: overwrite
        config_mode: private
        diff: true
        check: true
        commit: false
        src: "{{ junos_conf }}"
        provider: "{{ credential }}"
```
> there might be another issue here because we shouldn't have a lock on the configuration at this time since all tasks are running in `private` mode but I couldn't find where this lock was coming from so I fixed the ignore_arning issue... 

Looking at the code, this parameter was not passed to the function but a default value was already defined for `rpc.open_configuration`
```python
self.dev.rpc.open_configuration(
                        private=True,	                    
                        ignore_warning='uncommitted changes will be '	                       
                                       'discarded on exit')
```

This patch passed the `ignore_warning` arg to `open_configuration` and follow this logic: 
- if `ignore_warning` is a bool, pass the bool
- if `ignore_warning` is a string, create a list and add it to the default value
- if `ignore_warning` is a list, add the default value to the list

