### PR TITLE
Fixes issue #434

### DIFF
--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -510,6 +510,8 @@ def main():
                     attr = {}
                 if kwarg is None:
                     kwarg = {}
+                if format is not None:
+                    attr['format'] = format
                 junos_module.logger.debug('Executing "get-config" RPC. '
                                           'filter_xml=%s, options=%s, '
                                           'kwargs=%s',


### PR DESCRIPTION
RPC: `get_config` is treated specially in both PyEZ and juniper_junos_rpc. The current code doesn't pass the format option to PyEZ's `get_config`, which returns an XML response instead of text response, causing the incorrect behavior.

Corrected the behavior by passing down the format option to PyEZ.

Links:

https://github.com/Juniper/py-junos-eznc/blob/472408c3e7a8dd67001c09589c0cf35faad7e829/lib/jnpr/junos/rpcmeta.py#L26-L38