### PR TITLE
Adding docs to clarify the usage of ssh_private_key_file

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ should be added to the Ansible configuration file in order to allow the jsnapy c
 
 You must have the [DEPENDENCIES](#dependencies) installed on your system.  
 
+### NOTICES
+
+#### Ubuntu 14.04
+
 If you're dealing with Ubuntu 14.04 and faced following error during the installation, it's because the system python which used by Ubuntu 14.04 is locked to 2.7.6 till EOL, as a result, please consider to skip galaxy certification process by appending `-c` option of ansible-galaxy. i.e. `ansible-galaxy install Juniper.junos -c`
 
     [WARNING]: - Juniper.junos was NOT installed successfully: Failed to get data
@@ -103,6 +107,14 @@ If you're dealing with Ubuntu 14.04 and faced following error during the install
     '*.c1e4.galaxy.openshiftapps.com', 'c1e4.galaxy.openshiftapps.com'.
 
     ERROR! - you can use --ignore-errors to skip failed roles and finish processing the list.
+
+### MacOS Mojave and newer
+
+In MacOS Mojave and newer (>=10.14), ssh keys created with the system `ssh-keygen` are created using the newer 'OPENSSH' key format, even when specifying `-t rsa` during creation. This directly affects the usage of ssh keys, particularly when using the `ssh_private_key_file`. To create/convert/check keys, follow these steps:
+
+- Create a new RSA key: `ssh-keygen -m PEM -t rsa -b 4096`
+- Check existing keys: `head -n1 ~/.ssh/some_private_key` RSA keys will be `-----BEGIN RSA PRIVATE KEY-----` and OPENSSH keys will be `-----BEGIN OPENSSH PRIVATE KEY-----`
+- Convert an OPENSSH key to an RSA key: `ssh-keygen -p -m PEM -f ~/.ssh/some_key`
 
 ### Ansible Galaxy Role
 
@@ -246,9 +258,6 @@ Juniper Networks is actively contributing to and maintaining this repo. Please c
 [jnpr-community-netdev@juniper.net](jnpr-community-netdev@juniper.net) for any queries.
 
 *Contributors:*
-[Nitin Kumar](https://github.com/vnitinv), [Stacy W Smith](https://github.com/stacywsmith),
-[David Gethings](https://github.com/dgjnpr)
-
 [Nitin Kumar](https://github.com/vnitinv), [Stacy W Smith](https://github.com/stacywsmith), [Stephen Steiner](https://github.com/ntwrkguru)
 
 *Former Contributors:*

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -277,6 +277,13 @@ class ModuleDocFragment(object):
             is found using the algorithm below, then the SSH private key file
             specified in the user's SSH configuration, or the
             operating-system-specific default is used.
+          - This must be in the RSA PEM format, and not the newer OPENSSH
+            format. To check if the private key is in the correct format, issue
+            the command: `head -n1 ~/.ssh/some_private_key` and ensure that
+            it's RSA and not OPENSSH. To create a key in the RSA PEM format,
+            issue the command: `ssh-keygen -m PEM -t rsa -b 4096`. To convert
+            an OPENSSH key to an RSA key, issue the command: `ssh-keygen -p -m
+            PEM -f ~/.ssh/some_private_key`
         required: false
         default: The first defined value from the following list
                  1) The C(ANSIBLE_NET_SSH_KEYFILE) environment variable.


### PR DESCRIPTION
In newer versions of OpenSSH, keys are generated in the OPENSSH format, but paramiko needs the RSA PEM format. I've added instructions to check for, convert, and create keys in the proper format.