### PR TITLE
adding commit full functionality to junos_config module

### DIFF
--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -184,6 +184,12 @@ options:
     required: false
     default: false
     type: bool
+  commit_full:
+    description:
+      - Coupled with commit=True, this will perform a C(commit full) operation.
+    required: false
+    default: false
+    type: bool
   config_mode:
     description:
       - The mode used to access the candidate configuration database.
@@ -662,6 +668,17 @@ EXAMPLES = '''
     - name: Print the complete response
       debug:
         var: response
+
+    - name: Issue commit full
+      juniper_junos_config:
+        load: replace
+        format: 'set'
+        check: False
+        commit: True
+        commit_empty_changes: True
+        commit_full: True
+        lines:
+          - ''
 '''
 
 RETURN = '''
@@ -841,6 +858,9 @@ def main():
             commit_empty_changes=dict(required=False,
                                       type='bool',
                                       default=False),
+            commit_full=dict(required=False,
+                             type='bool',
+                             default=False),
             confirmed=dict(required=False,
                            type='int',
                            aliases=['confirm'],
@@ -893,6 +913,7 @@ def main():
     dest = junos_module.params.get('dest')
     commit = junos_module.params.get('commit')
     commit_empty_changes = junos_module.params.get('commit_empty_changes')
+    commit_full = junos_module.params.get('commit_full')
     confirmed = junos_module.params.get('confirmed')
     comment = junos_module.params.get('comment')
     check_commit_wait = junos_module.params.get('check_commit_wait')
@@ -1120,7 +1141,8 @@ def main():
                 time.sleep(check_commit_wait)
             junos_module.commit_configuration(ignore_warning=ignore_warning,
                                               comment=comment,
-                                              confirmed=confirmed)
+                                              confirmed=confirmed,
+                                              full=commit_full))
             results['msg'] += ', committed'
         else:
             junos_module.logger.debug("Skipping commit. Nothing changed.")

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -1711,7 +1711,7 @@ class JuniperJunosModule(AnsibleModule):
                                (str(ex)))
 
     def commit_configuration(self, ignore_warning=None, comment=None,
-                             confirmed=None):
+                             confirmed=None, full=False):
         """Commit the candidate configuration.
 
         Commit the configuration. Assumes the configuration is already opened.
@@ -1731,7 +1731,8 @@ class JuniperJunosModule(AnsibleModule):
         try:
             self.config.commit(ignore_warning=ignore_warning,
                                comment=comment,
-                               confirm=confirmed)
+                               confirm=confirmed,
+                               full=full)
             self.logger.debug("Configuration committed.")
         except (self.pyez_exception.RpcError,
                 self.pyez_exception.ConnectError) as ex:


### PR DESCRIPTION
This PR adds the ability to issue a `commit full` on Junos.