### PR TITLE
Adjusted priority between self.params and self.params['provider']

### DIFF
--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -745,7 +745,7 @@ class JuniperJunosModule(AnsibleModule):
                 if arg_name in self.aliases:
                     arg_name = self.aliases[arg_name]
                 # Some parameters like logfile and logdir can either be in
-                # provider os declared in the module params. The priority should
+                # provider or declared in the module params. The priority should
                 # be given to the module params in this case.
                 if self.params[arg_name] is None:
                     self.params[arg_name] = arg_value

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -744,7 +744,11 @@ class JuniperJunosModule(AnsibleModule):
             for arg_name, arg_value in self.params['provider'].items():
                 if arg_name in self.aliases:
                     arg_name = self.aliases[arg_name]
-                self.params[arg_name] = arg_value
+                # Some parameters like logfile and logdir can either be in
+                # provider os declared in the module params. The priority should
+                # be given to the module params in this case.
+                if self.params[arg_name] is None:
+                    self.params[arg_name] = arg_value
             self.params.pop('provider')
         # Parse the console option
         self._parse_console_options()


### PR DESCRIPTION
Some parameters like `logfile` and `logdir` can either be in `provider` or declared in the module params. The priority should be given to the module params in this case.

I have verified the fix for the following scenarios using `logdir` :
- Declared in module params and not in `provider`.
- Declared in `provider` and not in module params.
- Declared in both provider and module. It correctly picks up the directory in module params.