### PR TITLE
Updated dockerfile to install Juniper.junos via galaxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,18 @@ LABEL net.juniper.image.maintainer="Stephen Steiner <ssteiner@juniper.net>"
 
 WORKDIR /tmp
 
+RUN echo -e "http://nl.alpinelinux.org/alpine/v3.5/main\nhttp://nl.alpinelinux.org/alpine/v3.5/community" \
+    > /etc/apk/repositories
 RUN apk add --no-cache ca-certificates openssh-client build-base gcc g++ make python-dev py-pip
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt
+RUN ansible-galaxy install Juniper.junos
 
 RUN apk del -r --purge gcc make g++ &&\
     rm -rf /source/* &&\
     rm -rf /var/cache/apk/* &&\
     rm -rf /tmp/*
-
-WORKDIR /etc/ansible/roles/Juniper.junos
-COPY action_plugins action_plugins
-COPY callback_plugins callback_plugins
-COPY library library
-COPY meta meta
-COPY module_utils module_utils
 
 WORKDIR /playbooks
 


### PR DESCRIPTION
Logs:

```
/playbooks # ansible-galaxy list
# /root/.ansible/roles
- Juniper.junos, 2.2.1
[WARNING]: - the configured path /usr/share/ansible/roles does not exist.

[WARNING]: - the configured path /etc/ansible/roles does not exist.

```