### PR TITLE
Update juniper_junos_table.py

### DIFF
--- a/library/juniper_junos_table.py
+++ b/library/juniper_junos_table.py
@@ -329,7 +329,7 @@ def juniper_items_to_list_of_dicts(module, data):
         # table_fields - element 1 is also a list of tuples
         temp = {}
         for key, value in table_fields:
-            if (value and isinstance(value, module.pyez_factory_table.Table)):
+            if isinstance(value, module.pyez_factory_table.Table):
                 value = juniper_items_to_list_of_dicts(module, value)
             temp[key] = value
         resources.append(temp)


### PR DESCRIPTION
Checking for bool(value) when it is a nested table with no entries returns False, hence passes the Table object as a value instead of an empty list. In the end this fails in Ansible becuase it doesn't know how to digest that into a text.

This fixes issue #379