### PR TITLE
fix for ignore_warn_list for string types

### DIFF
--- a/ansible_collection/Juniper/junos/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collection/Juniper/junos/plugins/module_utils/juniper_junos_common.py
@@ -1201,13 +1201,15 @@ class JuniperJunosModule(AnsibleModule):
         if ignore_warn_list is None:
             return ignore_warn_list
         if len(ignore_warn_list) == 1:
-            bool_val = boolean(ignore_warn_list[0])
-            if bool_val is not None:
-                return bool_val
-            elif isinstance(ignore_warn_list[0], basestring):
-                return ignore_warn_list[0]
-            else:
-                self.fail_json(msg="The value of the ignore_warning option "
+            try:
+                bool_val = boolean(ignore_warn_list[0])
+                if bool_val is not None:
+                    return bool_val
+            except TypeError:
+                if isinstance(ignore_warn_list[0], basestring):
+                    return ignore_warn_list[0]
+
+            self.fail_json(msg="The value of the ignore_warning option "
                                    "(%s) is invalid. Unexpected type (%s)." %
                                    (ignore_warn_list[0],
                                     type(ignore_warn_list[0])))


### PR DESCRIPTION
Fix added if ignore_warn_list has string type character elements. 