### PR TITLE
Enabling whitelist feature for jsnapy callback

### DIFF
--- a/callback_plugins/jsnapy.py
+++ b/callback_plugins/jsnapy.py
@@ -20,6 +20,9 @@ class CallbackModule(CallbackBase):
   CALLBACK_TYPE = 'aggregate'
   CALLBACK_NAME = 'jsnapy'
 
+  # only needed if you ship it and don't want to enable by default
+  CALLBACK_NEEDS_WHITELIST = True
+
 ## useful links regarding Callback
 ## https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/callback/__init__.py
 

--- a/callback_plugins/jsnapy.py
+++ b/callback_plugins/jsnapy.py
@@ -20,7 +20,7 @@ class CallbackModule(CallbackBase):
   CALLBACK_TYPE = 'aggregate'
   CALLBACK_NAME = 'jsnapy'
 
-  # only needed if you ship it and don't want to enable by default
+  # callback needs to be enabled with config-file to use jsnapy callback during execution
   CALLBACK_NEEDS_WHITELIST = True
 
 ## useful links regarding Callback


### PR DESCRIPTION
Adding whitelist to be added in ansible.cfg for jsnapy callback to be enabled or disabled.
jsnapy callback will no more be enabled by default. 