### PR TITLE
Adding ignore warning for diff in juniper junos config

### DIFF
--- a/library/juniper_junos_command.py
+++ b/library/juniper_junos_command.py
@@ -134,6 +134,18 @@ options:
       - format
       - display
       - output
+  ignore_warning:
+    description:
+      - A boolean, string or list of strings. If the value is C(true),
+        ignore all warnings regardless of the warning message. If the value
+        is a string, it will ignore warning(s) if the message of each warning
+        matches the string. If the value is a list of strings, ignore
+        warning(s) if the message of each warning matches at least one of the
+        strings in the list. The value of the I(ignore_warning) option is
+        applied to the load and commit operations performed by this module.
+    required: false
+    default: none
+    type: bool, str, or list of str
   return_output:
     description:
       - Indicates if the output of the command should be returned in the
@@ -332,6 +344,9 @@ def main():
                           type='path',
                           aliases=['destination_dir', 'destdir'],
                           default=None),
+            ignore_warning=dict(required=False,
+                                type='list',
+                                default=None),
             return_output=dict(required=False,
                                type='bool',
                                default=True)
@@ -344,6 +359,9 @@ def main():
         supports_check_mode=True,
         min_jxmlease_version=juniper_junos_common.MIN_JXMLEASE_VERSION,
     )
+
+    # Parse ignore_warning value
+    ignore_warning = junos_module.parse_ignore_warning_option()
 
     # Check over commands
     commands = junos_module.params.get('commands')
@@ -413,7 +431,7 @@ def main():
                                       command)
             rpc = junos_module.etree.Element('command', format=format)
             rpc.text = command
-            resp = junos_module.dev.rpc(rpc, normalize=bool(format == 'xml'))
+            resp = junos_module.dev.rpc(rpc, ignore_warning=ignore_warning, normalize=bool(format == 'xml'))
             result['msg'] = 'The command executed successfully.'
             junos_module.logger.debug('Command "%s" executed successfully.',
                                       command)

--- a/library/juniper_junos_config.py
+++ b/library/juniper_junos_config.py
@@ -1077,7 +1077,7 @@ def main():
                               "candidate and committed configuration "
                               "databases.")
     if diff is True or junos_module._diff:
-        diff = junos_module.diff_configuration()
+        diff = junos_module.diff_configuration(ignore_warning)
         if diff is not None:
             results['changed'] = True
             if return_output is True or junos_module._diff:

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -1570,7 +1570,7 @@ class JuniperJunosModule(AnsibleModule):
 
         self.logger.debug("Diffing candidate and committed configurations.")
         try:
-	    rb_id =0
+            rb_id =0
             diff = self.config.diff(rb_id, ignore_warning)
             self.logger.debug("Configuration diff completed.")
             return diff

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -1570,8 +1570,7 @@ class JuniperJunosModule(AnsibleModule):
 
         self.logger.debug("Diffing candidate and committed configurations.")
         try:
-            rb_id =0
-            diff = self.config.diff(rb_id, ignore_warning)
+            diff = self.config.diff(rb_id=0, ignore_warning=ignore_warning)
             self.logger.debug("Configuration diff completed.")
             return diff
         except (self.pyez_exception.RpcError,

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -1570,7 +1570,8 @@ class JuniperJunosModule(AnsibleModule):
 
         self.logger.debug("Diffing candidate and committed configurations.")
         try:
-            diff = self.config.diff(rb_id=0, ignore_warning)
+	    rb_id =0
+            diff = self.config.diff(rb_id, ignore_warning)
             self.logger.debug("Configuration diff completed.")
             return diff
         except (self.pyez_exception.RpcError,

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -1554,7 +1554,7 @@ class JuniperJunosModule(AnsibleModule):
             self.fail_json(msg='Failure checking the configuraton: %s' %
                                (str(ex)))
 
-    def diff_configuration(self):
+    def diff_configuration(self, ignore_warning=False):
         """Diff the candidate and committed configurations.
 
         Diff the candidate and committed configurations.
@@ -1570,7 +1570,7 @@ class JuniperJunosModule(AnsibleModule):
 
         self.logger.debug("Diffing candidate and committed configurations.")
         try:
-            diff = self.config.diff(rb_id=0)
+            diff = self.config.diff(rb_id=0, ignore_warning)
             self.logger.debug("Configuration diff completed.")
             return diff
         except (self.pyez_exception.RpcError,


### PR DESCRIPTION
Pass and parse the ignore_warning argument in diff for juniper_junos_config.