### PR TITLE
Correct message  in case of failure during software install

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ This Juniper.junos role includes the following modules:
 - **juniper_junos_system** — Initiate operational actions on the Junos system.
 - **juniper_junos_table** — Retrieve data from a Junos device using a PyEZ table/view.
 
+### PyEZ Version Requirement
+For ansible roles 2.4.0 we will need to install junos-eznc(PyEZ) version 2.5.0 or higher. 
+
 ### Important Changes
 
 Significant changes to the modules in the Juniper.junos role were made between versions 1.4.3 and 2.0.0.

--- a/library/juniper_junos_software.py
+++ b/library/juniper_junos_software.py
@@ -686,13 +686,14 @@ def main():
             junos_module.logger.debug("Install parameters are: %s",
                                        str(install_params))
             junos_module.add_sw()
-            ok = junos_module.sw.install(**install_params)
+            ok, msg_ret = junos_module.sw.install(**install_params)
             if ok is not True:
-                results['msg'] = 'Unable to install the software %s',ok
+                results['msg'] = 'Unable to install the software %s', msg_ret
                 junos_module.fail_json(**results)
-            msg = 'Package %s successfully installed.' % (
+            msg = 'Package %s successfully installed. Response from device is: %s' % (
                         install_params.get('package') or
-                        install_params.get('pkg_set'))
+                        install_params.get('pkg_set'),
+                        msg_ret)
             results['msg'] = msg
             junos_module.logger.debug(msg)
         except (junos_module.pyez_exception.ConnectError,

--- a/library/juniper_junos_software.py
+++ b/library/juniper_junos_software.py
@@ -688,7 +688,7 @@ def main():
             junos_module.add_sw()
             ok = junos_module.sw.install(**install_params)
             if ok is not True:
-                results['msg'] = 'Unable to install the software'
+                results['msg'] = 'Unable to install the software %s',ok
                 junos_module.fail_json(**results)
             msg = 'Package %s successfully installed.' % (
                         install_params.get('package') or

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ansible >= 2.4
-junos-eznc
-jsnapy==1.3.2
+junos-eznc >= 2.5.0
+jsnapy>=1.3.2
 jxmlease
 docker
 junos-netconify

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
-VERSION = "2.3.2"
-DATE = "2020-May-28"
+VERSION = "2.4.0"
+DATE = "2020-June-30"


### PR DESCRIPTION
When there is insufficient space left on the device, juniper_junos_software module needs to return a correct error when the upgrade procedure tries to untar the image. 
#495 