### PR TITLE
Modify kwargs bool value check in rpc module

### DIFF
--- a/library/juniper_junos_rpc.py
+++ b/library/juniper_junos_rpc.py
@@ -169,6 +169,13 @@ options:
         two lists must always contain the same number of elements. For RPC
         arguments which do not require a value, specify the value of True as
         shown in the :ref:`juniper_junos_rpc-examples-label`.
+      - By default "0" and "1" will be converted to boolean values. In case 
+        it doesn't need to be transformed to boolean pass first kwargs as 
+        allow_bool_values : "0"
+        example - 
+        kwargs:
+          allow_bool_values: "0"
+          data: "1"
     required: false
     default: none
     type: dict or list of dict

--- a/module_utils/juniper_junos_common.py
+++ b/module_utils/juniper_junos_common.py
@@ -1175,6 +1175,11 @@ class JuniperJunosModule(AnsibleModule):
                                    "invalid. Unable to translate into a list "
                                    "of dicts." %
                                    (option_name, string_val))
+
+            # check if allow_bool_values passed in kwargs
+            if "allow_bool_values" in kwarg:
+                allow_bool_values = kwarg.pop("allow_bool_values")
+
             # Now we just need to make sure the key is a string and the value
             # is a string or bool.
             return_item = {}


### PR DESCRIPTION
For kwargs in rpc the module checks if the value can be transformed to bool and converts it. 
A flag can now be added in the kwargs to not convert into bool and keep the value as string. 

The mandatory boolean conversion is not removed to keep backward compatibility. 

For ex - 
juniper_junos_rpc:
        rpc: get-rollback-information
        kwargs:
          allow_bool_values: "0"
          rollback: "2"
          compare: 0
          
it will resolve #538 