### PR TITLE
Adding allow_bool for rpc and enhancing log error

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -560,6 +560,15 @@ class JuniperJunosModule(AnsibleModule):
             A JuniperJunosModule instance object.
         """
 
+        #initialize default values here for error scenario while super is called
+
+        # by default local
+        self.conn_type = "local"
+        # Initialize the dev attribute
+        self.dev = None
+        # Initialize the config attribute
+        self.config = None
+
         # Update argument_spec with the internal_spec
         argument_spec.update(internal_spec)
         # Update argument_spec with the top_spec
@@ -622,11 +631,6 @@ class JuniperJunosModule(AnsibleModule):
 
         # Parse the console option
         self._parse_console_options()
-
-        # Initialize the dev attribute
-        self.dev = None
-        # Initialize the config attribute
-        self.config = None
 
         # Check that we have a user and host
         if not self.params.get('host'):
@@ -944,6 +948,10 @@ class JuniperJunosModule(AnsibleModule):
                                    "invalid. Unable to translate into a list "
                                    "of dicts." %
                                    (option_name, string_val))
+            # check if allow_bool_values passed in kwargs
+            if "allow_bool_values" in kwarg:
+                allow_bool_values = kwarg.pop("allow_bool_values")
+
             # Now we just need to make sure the key is a string and the value
             # is a string or bool.
             return_item = {}

--- a/ansible_collections/juniper/device/plugins/modules/rpc.py
+++ b/ansible_collections/juniper/device/plugins/modules/rpc.py
@@ -164,6 +164,13 @@ options:
         two lists must always contain the same number of elements. For RPC
         arguments which do not require a value, specify the value of True as
         shown in the :ref:`rpc-examples-label`.
+      - By default "0" and "1" will be converted to boolean values. In case 
+        it doesn't need to be transformed to boolean pass first kwargs as 
+        allow_bool_values : "0"
+        example - 
+        kwargs:
+          allow_bool_values: "0"
+          data: "1"
     required: false
     default: none
     type: dict or list of dict


### PR DESCRIPTION
For kwargs in rpc the module checks if the value can be transformed to bool and converts it.
A flag can now be added in the kwargs to not convert into bool and keep the value as string.

The mandatory boolean conversion is not removed to keep backward compatibility.

For ex -
juniper_junos_rpc:
rpc: get-rollback-information
kwargs:
allow_bool_values: "0"
rollback: "2"
compare: 0

it will resolve #538 in collections. 