### PR TITLE
add requirements.txt file link to device collection

### DIFF
--- a/ansible_collections/juniper/device/requirements.txt
+++ b/ansible_collections/juniper/device/requirements.txt
@@ -1,0 +1,1 @@
+../../../requirements.txt


### PR DESCRIPTION
add link to the root folder requirements.txt file in the device collection so that when building ansible execution-environments with ansible-builder the introspect will automatically pickup the python dependencies for the build.