### PR TITLE
accounting for deprecation of yaml.load() function

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/table.py
+++ b/ansible_collections/juniper/device/plugins/modules/table.py
@@ -386,7 +386,7 @@ def main():
             try:
                 junos_module.logger.debug("Attempting to parse YAML from : "
                                           "%s.", file_name)
-                table_view = junos_module.yaml.load(fp)
+                table_view = junos_module.yaml.safe_load(fp)
                 junos_module.logger.debug("YAML from %s successfully parsed.",
                                           file_name)
             except junos_module.yaml.YAMLError as ex:


### PR DESCRIPTION
[deprecation notice](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)

The `load()` function now requires parameter `loader=Loader`, which will be enough to break the ability to load YAML within the `table.py` module.

Since the YAML file contains data types (str, int, lists), we updated the call to use `yaml.safe_load()` instead.

## without adjusting the load function:

> pb.get.arp.yaml

```yaml
    - name: Get ARP information using Junos PyEZ Table
      table:        
        user: "root"
        passwd: "juniper123"
        file: "arp.yaml"
        path: "{{ playbook_dir }}"
      register: result
```

> execution will fail

```bash
`--> ansible-playbook pb.get.arp.yaml

PLAY [all] *****************************************************************************************************************************************************************

TASK [Get ARP information using Junos PyEZ Table] **************************************************************************************************************************
Monday 10 January 2022  22:36:45 +0000 (0:00:04.469)       0:00:04.528 ******** 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: load() missing 1 required positional argument: 'Loader'
fatal: [houston]: FAILED! => changed=false 
  module_stderr: |-
    Traceback (most recent call last):
      File "/home/cdot/.ansible/tmp/ansible-tmp-1641854205.0888155-3743845-140999149617734/AnsiballZ_table.py", line 107, in <module>
        _ansiballz_main()
      File "/home/cdot/.ansible/tmp/ansible-tmp-1641854205.0888155-3743845-140999149617734/AnsiballZ_table.py", line 99, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/home/cdot/.ansible/tmp/ansible-tmp-1641854205.0888155-3743845-140999149617734/AnsiballZ_table.py", line 47, in invoke_module
        runpy.run_module(mod_name='ansible_collections.juniper.device.plugins.modules.table', init_globals=dict(_module_fqn='ansible_collections.juniper.device.plugins.modules.table', _modlib_path=modlib_path),
      File "/usr/lib/python3.8/runpy.py", line 207, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib/python3.8/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_table_payload_yobk51jw/ansible_table_payload.zip/ansible_collections/juniper/device/plugins/modules/table.py", line 481, in <module>
      File "/tmp/ansible_table_payload_yobk51jw/ansible_table_payload.zip/ansible_collections/juniper/device/plugins/modules/table.py", line 389, in main
    TypeError: load() missing 1 required positional argument: 'Loader'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```

> swapping to safe_load() function

```yaml
`--> ansible-playbook pb.get.arp.yaml
TASK [Get ARP information using Junos PyEZ Table] **************************************************************************************************************************
Monday 10 January 2022  22:39:51 +0000 (0:00:04.081)       0:00:04.111 ******** 
ok: [houston]

TASK [Print response] ******************************************************************************************************************************************************
Monday 10 January 2022  22:39:54 +0000 (0:00:02.794)       0:00:06.905 ******** 
ok: [houston] => 
  result:
    changed: false
    failed: false
    msg: Successfully retrieved 3 items from ArpTable.
    resource:
    - interface_name: em1.0
      ip_address: 128.0.0.16
      mac_address: '50:00:00:07:00:01'
    - interface_name: fxp0.0
      ip_address: 192.168.110.1
      mac_address: 00:10:db:ff:10:01
    - interface_name: fxp0.0
      ip_address: 192.168.110.14
      mac_address: '50:00:14:02:00:00'
```