### PR TITLE
Improve handling of complex RPC's

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1518,7 +1518,7 @@ class JuniperJunosModule(AnsibleModule):
                                (str(ex)))
 
     def commit_configuration(self, ignore_warning=None, comment=None,
-                             confirmed=None, timeout=30, full=False):
+                             confirmed=None, full=False):
         """Commit the candidate configuration.
 
         Commit the configuration. Assumes the configuration is already opened.
@@ -1527,14 +1527,13 @@ class JuniperJunosModule(AnsibleModule):
             ignore_warning - Which warnings to ignore.
             comment - The commit comment
             confirmed - Number of minutes for commit confirmed.
-            timeout - Timeout for commit configuration. Default timeout value is 30s.
             full - apply full commit
 
         Failures:
             - An error returned from committing the configuration.
         """
         if self.conn_type != "local":
-            self._pyez_conn.commit_configuration(ignore_warning, comment, timeout, confirmed)
+            self._pyez_conn.commit_configuration(ignore_warning, comment, self.params.get('timeout'), confirmed)
             return
 
         if self.dev is None or self.config is None:
@@ -1545,7 +1544,7 @@ class JuniperJunosModule(AnsibleModule):
             self.config.commit(ignore_warning=ignore_warning,
                                comment=comment,
                                confirm=confirmed,
-                               timeout=timeout,
+                               timeout=self.params.get('timeout'),
                                full=full)
             self.logger.debug("Configuration committed.")
         except (self.pyez_exception.RpcError,

--- a/ansible_collections/juniper/device/plugins/modules/rpc.py
+++ b/ansible_collections/juniper/device/plugins/modules/rpc.py
@@ -388,14 +388,14 @@ def main():
                          default=None),
             kwargs=dict(required=False,
                         aliases=['kwarg', 'args', 'arg'],
-                        type='str',
+                        type='list',
                         default=None),
             attrs=dict(required=False,
-                       type='str',
+                       type='list',
                        aliases=['attr'],
                        default=None),
             filter=dict(required=False,
-                        type='str',
+                        type='list',
                         aliases=['filter_xml'],
                         default=None),
             dest=dict(required=False,
@@ -532,13 +532,16 @@ def main():
                                           'successfully.')
             else:
                 if kwarg is not None:
-                    # Add kwarg
-                    for (key, value) in iteritems(kwarg):
-                        # Replace underscores with dashes in key name.
-                        key = key.replace('_', '-')
-                        sub_element = junos_module.etree.SubElement(rpc, key)
-                        if not isinstance(value, bool):
-                            sub_element.text = value
+                    def iterdict(d, parent):
+                        for (key, value) in iteritems(d):
+                            # Replace underscores with dashes in key name.
+                            key = key.replace('_', '-')
+                            sub_element = junos_module.etree.SubElement(parent, key)
+                            if isinstance(value, dict):
+                                iterdict(value, sub_element)
+                            elif not isinstance(value, bool):
+                                sub_element.text = value
+                    iterdict(kwarg, rpc)
                 if attr is not None:
                     # Add attr
                     for (key, value) in iteritems(attr):


### PR DESCRIPTION
These changes work for me to resolve the issues I noted in #589 - I believe them to be safe and not cause any changes in behaviour (mostly because it doesn't appear the current behaviour works) but I don't have an extensive library of tasks to check these against as I'm working on a brand new deployment. But you may want to rework them, as I'm not familiar with ansible's best practices for module development.

This change does three things:
* Port usage of _check_type_dict to support Ansible 4+
I've tried to maintain compatibility with Ansible 2.9 by adding a fallback.

* Changes the type of attrs, kwargs, and filter to list, avoiding round-tripping them from list to string to list. This is a problem, because safe_eval will not process lists with certain keywords that are common in JunOS configs.
I believe this is a safe change, as if a user has e.g. "kwarg: 'foo'" Ansible will transparently convert it to "['foo']".

* Allows an RPC to have nested configuration - this is required for e.g. validate, which needs to generate:
```
<rpc>
  <validate>
    <candidate/>
  </validate>
</rpc>
```
This is done recursively.