### PR TITLE
fix: add inventory_hostname to host list

### DIFF
--- a/ansible_collections/juniper/device/plugins/connection/pyez.py
+++ b/ansible_collections/juniper/device/plugins/connection/pyez.py
@@ -52,6 +52,7 @@ options:
     - name: host
     - name: hostname
     - name: ip
+    - name: inventory_hostname
   port:
     description:
     - Specifies the port on the remote device that listens for connections when establishing


### PR DESCRIPTION
It seems that the even though a default value is defined, it is now expected to be explicitly listed in the options.

Fixes the following warning message: `[WARNING]: The "ansible_collections.juniper.device.plugins.connection.pyez" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string`

