### PR TITLE
Introduced commit_sync and commit_force_sync

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1503,7 +1503,8 @@ class JuniperJunosModule(AnsibleModule):
                                (str(ex)))
 
     def commit_configuration(self, ignore_warning=None, comment=None,
-                             confirmed=None, timeout=30, full=False):
+                             confirmed=None, timeout=30, full=False,
+                             sync=False, force_sync=False):
         """Commit the candidate configuration.
 
         Commit the configuration. Assumes the configuration is already opened.
@@ -1514,6 +1515,8 @@ class JuniperJunosModule(AnsibleModule):
             confirmed - Number of minutes for commit confirmed.
             timeout - Timeout for commit configuration. Default timeout value is 30s.
             full - apply full commit
+            sync - Check for commit syntax and sync between RE's
+            force_sync - Ignore syntax check and force to sync between RE's
 
         Failures:
             - An error returned from committing the configuration.
@@ -1531,7 +1534,9 @@ class JuniperJunosModule(AnsibleModule):
                                comment=comment,
                                confirm=confirmed,
                                timeout=timeout,
-                               full=full)
+                               full=full,
+                               force_sync=force_sync,
+                               sync=sync)
             self.logger.debug("Configuration committed.")
         except (self.pyez_exception.RpcError,
                 self.pyez_exception.ConnectError) as ex:

--- a/ansible_collections/juniper/device/plugins/modules/config.py
+++ b/ansible_collections/juniper/device/plugins/modules/config.py
@@ -184,6 +184,21 @@ options:
     required: false
     default: false
     type: bool
+  commit_sync:
+    description:
+      - On dual control plane systems, requests that the candidate configuration
+        on one control plane be copied to the other control plane, checked for
+        correct syntax, and committed on both Routing engines.
+    required: false
+    default: false
+    type: bool
+  commit_force_sync:
+    description:
+      - On dual control plane systems, forces the candidate configuration
+        on one control plane to be copied to the other control plane.
+    required: false
+    default: false
+    type: bool
   config_mode:
     description:
       - The mode used to access the candidate configuration database.
@@ -893,6 +908,12 @@ def main():
             commit_full=dict(required=False,
                              type='bool',
                              default=False),
+            commit_sync=dict(required=False,
+                             type='bool',
+                             default=False),
+            commit_force_sync=dict(required=False,
+                                   type='bool',
+                                   default=False),
             confirmed=dict(required=False,
                            type='int',
                            aliases=['confirm'],
@@ -946,6 +967,8 @@ def main():
     commit = junos_module.params.get('commit')
     commit_empty_changes = junos_module.params.get('commit_empty_changes')
     commit_full = junos_module.params.get('commit_full')
+    commit_sync = junos_module.params.get('commit_sync')
+    commit_force_sync = junos_module.params.get('commit_force_sync')
     confirmed = junos_module.params.get('confirmed')
     comment = junos_module.params.get('comment')
     check_commit_wait = junos_module.params.get('check_commit_wait')
@@ -1174,7 +1197,9 @@ def main():
             junos_module.commit_configuration(ignore_warning=ignore_warning,
                                               comment=comment,
                                               confirmed=confirmed,
-                                              full=commit_full)
+                                              full=commit_full,
+                                              sync=commit_sync,
+                                              force_sync=commit_force_sync)
             results['msg'] += ', committed'
         else:
             junos_module.logger.debug("Skipping commit. Nothing changed.")


### PR DESCRIPTION
Introduced "commit_sync" and "commit_force_sync" under juniper.device.config module

```
    - name: "Confirm the commit with a commit check"
      juniper.device.config:
        check: true
        diff: false
        comment: "Juniper Network"
        commit_force_sync: True
      register: response
```


```
    - name: "Confirm the commit with a commit check"
      juniper.device.config:
        check: true
        diff: false
        comment: "Juniper Network"
        commit_sync: True
      register: response
```


