### PR TITLE
Fix for issue #620

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -43,6 +43,7 @@ import jnpr
 from jnpr.junos.utils.sw import SW
 from jnpr.junos import exception as pyez_exception
 from ncclient.operations.errors import TimeoutExpiredError
+from ansible.module_utils.common.validation import check_type_dict
 
 # Standard library imports
 from argparse import ArgumentParser
@@ -932,7 +933,7 @@ class JuniperJunosModule(AnsibleModule):
             # This might be a keyword1=value1 keyword2=value2 type string.
             # The _check_type_dict method will parse this into a dict for us.
             try:
-                kwargs = self._check_type_dict(kwargs)
+                kwargs = check_type_dict(kwargs)
             except TypeError as exc:
                 self.fail_json(msg="The value of the %s option (%s) is "
                                    "invalid. Unable to translate into "
@@ -955,7 +956,7 @@ class JuniperJunosModule(AnsibleModule):
                 # This might be a keyword1=value1 keyword2=value2 type string.
                 # The _check_type_dict method will parse this into a dict.
                 try:
-                    kwarg = self._check_type_dict(kwarg)
+                    kwarg = check_type_dict(kwarg)
                 except TypeError as exc:
                     self.fail_json(msg="The value of the %s option (%s) is "
                                        "invalid. Unable to translate into a "


### PR DESCRIPTION
As per Ansible documentation 
https://github.com/ansible/ansible/blob/6ac0ea35672eed7778f530b5cc7751d41b09c43a/docs/docsite/rst/porting_guides/porting_guide_core_2.11.rst#id27
_check_type_dict() is removed
_check_type_dict() --> [:func:`ansible.module_utils.common.validation.check_type_dict`]

Logs:

```
~/ansible_release_v103/ansible-junos-stdlib/tests# cat pb.juniper_junos_persistent_conn.yml 
---
- name: Test juniper.device.rpc module
  hosts: all
  connection: juniper.device.pyez
  gather_facts: no
  collections:
    - juniper.device

  tasks:
#################
    - name: Get Device Configuration for interface
      rpc:
        rpc: get-config
        format: xml
        filter: <configuration><groups><name>re0</name></groups></configuration>
        attr: name=re0
      register: test7
      ignore_errors: True
      tags: [ test7 ]

    - name: Check TEST 7
      assert:
        that:
          - test7.msg == "The \"get-config\" RPC executed successfully."
      tags: [ test7 ]
(venv) root@nms5-salt-master-b:~/ansible_release_v103/ansible-junos-stdlib/tests# ansible-playbook pb.juniper_junos_persistent_conn.yml 

PLAY [Test juniper.device.rpc module] *************************************************************************************************************************************

TASK [Get Device Configuration for interface] *****************************************************************************************************************************
ok: [test]

TASK [Check TEST 7] *******************************************************************************************************************************************************
ok: [test] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP ****************************************************************************************************************************************************************
test                       : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


~/ansible_release_v103/ansible-junos-stdlib/tests# ansible-playbook pb.juniper_junos_persistent_conn.yml -vvv
ansible-playbook [core 2.15.5]
  config file = /root/ansible_release_v103/ansible-junos-stdlib/tests/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible_release_v103/venv/lib/python3.9/site-packages/ansible
  ansible collection location = /root/ansible_release_v103/ansible-junos-stdlib/ansible_collections
  executable location = /root/ansible_release_v103/venv/bin/ansible-playbook
  python version = 3.9.6 (default, Oct 18 2021, 17:33:10) [GCC 7.5.0] (/root/ansible_release_v103/venv/bin/python)
  jinja version = 3.1.2
  libyaml = True
Using /root/ansible_release_v103/ansible-junos-stdlib/tests/ansible.cfg as config file
host_list declined parsing /root/ansible_release_v103/ansible-junos-stdlib/tests/inventory as it did not pass its verify_file() method
script declined parsing /root/ansible_release_v103/ansible-junos-stdlib/tests/inventory as it did not pass its verify_file() method
auto declined parsing /root/ansible_release_v103/ansible-junos-stdlib/tests/inventory as it did not pass its verify_file() method
Parsed /root/ansible_release_v103/ansible-junos-stdlib/tests/inventory inventory source with ini plugin
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: pb.juniper_junos_persistent_conn.yml ****************************************************************************************************************************
1 plays in pb.juniper_junos_persistent_conn.yml

PLAY [Test juniper.device.rpc module] *************************************************************************************************************************************

TASK [Get Device Configuration for interface] *****************************************************************************************************************************
task path: /root/ansible_release_v103/ansible-junos-stdlib/tests/pb.juniper_junos_persistent_conn.yml:11
<10.53.102.143> ESTABLISH LOCAL CONNECTION FOR USER: root
<10.53.102.143> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-local-14656jccufypp `"&& mkdir "` echo /root/.ansible/tmp/ansible-local-14656jccufypp/ansible-tmp-1697543768.2734084-14661-239470090690905 `" && echo ansible-tmp-1697543768.2734084-14661-239470090690905="` echo /root/.ansible/tmp/ansible-local-14656jccufypp/ansible-tmp-1697543768.2734084-14661-239470090690905 `" ) && sleep 0'
Using module file /root/ansible_release_v103/ansible-junos-stdlib/ansible_collections/juniper/device/plugins/modules/rpc.py
<10.53.102.143> PUT /root/.ansible/tmp/ansible-local-14656jccufypp/tmpjcsjmqvl TO /root/.ansible/tmp/ansible-local-14656jccufypp/ansible-tmp-1697543768.2734084-14661-239470090690905/AnsiballZ_rpc.py
<10.53.102.143> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-local-14656jccufypp/ansible-tmp-1697543768.2734084-14661-239470090690905/ /root/.ansible/tmp/ansible-local-14656jccufypp/ansible-tmp-1697543768.2734084-14661-239470090690905/AnsiballZ_rpc.py && sleep 0'
<10.53.102.143> EXEC /bin/sh -c '/root/ansible_release_v103/venv/bin/python /root/.ansible/tmp/ansible-local-14656jccufypp/ansible-tmp-1697543768.2734084-14661-239470090690905/AnsiballZ_rpc.py && sleep 0'
<10.53.102.143> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-local-14656jccufypp/ansible-tmp-1697543768.2734084-14661-239470090690905/ > /dev/null 2>&1 && sleep 0'
ok: [test] => {
    "attrs": {
        "format": "xml",
        "name": "re0"
    },
    "changed": false,
    "format": "xml",
    "invocation": {
        "module_args": {
            "attempts": null,
            "attr": "name=re0",
            "attrs": "name=re0",
            "baud": null,
            "console": null,
            "cs_passwd": null,
            "cs_user": null,
            "dest": null,
            "dest_dir": null,
            "filter": "<configuration><groups><name>re0</name></groups></configuration>",
            "format": "xml",
            "formats": [
                "xml"
            ],
            "host": "xx.xx.xx.xx",
            "huge_tree": false,
            "ignore_warning": null,
            "kwargs": null,
            "level": null,
            "logdir": null,
            "logfile": null,
            "mode": null,
            "passwd": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 22,
            "return_output": true,
            "rpc": "get-config",
            "rpcs": [
                "get-config"
            ],
            "ssh_config": null,
            "ssh_private_key_file": null,
            "timeout": 10,
            "user": "root"
        }
    },
    "kwargs": null,
    "msg": "The \"get-config\" RPC executed successfully.",
    "parsed_output": {
        "configuration": {
            "groups": {
                "interfaces": {
                    "interface": {
                        "name": "fxp0",
                        "unit": {
                            "family": {
                                "inet": {
                                    "address": {
                                        "name": "xx.xx.xx.xx./19"
                                    }
                                }
                            },
                            "name": "0"
                        }
                    }
                },
                "name": "re0",
                "system": {
                    "backup-router": {
                        "address": "xx.xx.xx.xx."
                    },
                    "host-name": "evoeventtestx"
                }
            }
        }
    },
    "rpc": "get-config",
    "stdout": "<configuration changed-seconds=\"1697452040\" changed-localtime=\"2023-10-16 03:27:20 PDT\">\n  <groups>\n    <name>re0</name>\n    <system>\n      <host-name>evoeventtestx</host-name>\n      <backup-router>\n        <address>xx.xx.xx.xx</address>\n      </backup-router>\n    </system>\n    <interfaces>\n      <interface>\n        <name>fxp0</name>\n        <unit>\n          <name>0</name>\n          <family>\n            <inet>\n              <address>\n                <name>xx.xx.xx.xx/19</name>\n              </address>\n            </inet>\n          </family>\n        </unit>\n      </interface>\n    </interfaces>\n  </groups>\n</configuration>\n",
    "stdout_lines": [
        "<configuration changed-seconds=\"1697452040\" changed-localtime=\"2023-10-16 03:27:20 PDT\">",
        "  <groups>",
        "    <name>re0</name>",
        "    <system>",
        "      <host-name>evoeventtestx</host-name>",
        "      <backup-router>",
        "        <address>xx.xx.xx.xx</address>",
        "      </backup-router>",
        "    </system>",
        "    <interfaces>",
        "      <interface>",
        "        <name>fxp0</name>",
        "        <unit>",
        "          <name>0</name>",
        "          <family>",
        "            <inet>",
        "              <address>",
        "                <name>xx.xx.xx.xx/19</name>",
        "              </address>",
        "            </inet>",
        "          </family>",
        "        </unit>",
        "      </interface>",
        "    </interfaces>",
        "  </groups>",
        "</configuration>"
    ]
}

TASK [Check TEST 7] *******************************************************************************************************************************************************
task path: /root/ansible_release_v103/ansible-junos-stdlib/tests/pb.juniper_junos_persistent_conn.yml:21
ok: [test] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP ****************************************************************************************************************************************************************
test                       : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

``