### PR TITLE
Supported configuration mode: private, batch, dynamic, exclusive and ephemeral

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/config.py
+++ b/ansible_collections/juniper/device/plugins/modules/config.py
@@ -60,6 +60,20 @@ description:
        * If the I(config_mode) option has a value of C(private), open a private
          candidate configuration database. If opening the private configuration
          database fails the module fails and reports an error.
+       * If the I(config_mode) option has a value of C(dynamic), open a dynamic
+         candidate configuration database. If opening the dynamic configuration
+         database fails the module fails and reports an error.
+       * If the I(config_mode) option has a value of C(batch), open a batch
+         candidate configuration database. If opening the batch configuration
+         database fails the module fails and reports an error.
+       * If the I(config_mode) option has a value of C(ephemeral), open a default
+         ephemeral candidate configuration database. If opening the ephemeral
+         configuration database fails the module fails and reports an error.
+       * If the I(ephemeral_instance) option has a value of C(ephemeral instance
+         name) along with I(config_mode) option has a value of C(ephemeral), open
+         a user defined ephemeral instance candidate configuration database. If
+         opening the ephemeral onfiguration database fails the module fails
+         and reports an error.
     #. Load configuration data into the candidate configuration database.
        
        * Configuration data may be loaded using the I(load) or I(rollback)
@@ -208,10 +222,19 @@ options:
     choices:
       - exclusive
       - private
+      - dynamic
+      - batch
+      - ephemeral
     aliases:
       - config_access
       - edit_mode
       - edit_access
+  ephemeral_instance:
+    description:
+      - To open a user-defined instance of the ephemeral database
+    required: false
+    default: None
+    type: str
   confirmed:
     description:
       - Provide a confirmed timeout, in minutes, to be used with the commit
@@ -826,6 +849,9 @@ def main():
                              aliases=['config_access', 'edit_mode',
                                       'edit_access'],
                              default='exclusive'),
+            ephemeral_instance=dict(type='str',
+                                    required=False,
+                                    default=None),
             rollback=dict(type='str',
                           required=False,
                           default=None),
@@ -943,6 +969,7 @@ def main():
 
     # Straight from params
     config_mode = junos_module.params.get('config_mode')
+    ephemeral_instance = junos_module.params.get('ephemeral_instance')
 
     # Parse rollback value
     rollback = junos_module.parse_rollback_option()
@@ -976,6 +1003,10 @@ def main():
     remove_ns = junos_module.params.get('remove_ns')
     namespace = junos_module.params.get('namespace')
 
+    # Ephemeral database doesn't support "show | compare",
+    # so setting diff to False.
+    if config_mode == 'ephemeral':
+        diff = False
 
     # If retrieve is set and load and rollback are not set, then
     # check, diff, and commit default to False.
@@ -1092,7 +1123,8 @@ def main():
 
     junos_module.logger.debug("Step 1 - Open a candidate configuration "
                               "database.")
-    junos_module.open_configuration(mode=config_mode, ignore_warning=ignore_warning)
+    junos_module.open_configuration(mode=config_mode, ignore_warning=ignore_warning,
+                                              ephemeral_instance=ephemeral_instance)
     results['msg'] += 'opened'
 
     junos_module.logger.debug("Step 2 - Load configuration data into the "


### PR DESCRIPTION
1. Supported config mode : private, batch, dynamic, exclusive.
2. By default, config mode is exclusive.
3. Supported config mode : ephemeral (default) and ephemeral (user defined instance).
4. Ephemeral db doesn't support "show | compare" command. So, set diff as False in case of config mode ephemeral.

root@> configure ephemeral
warning: uncommitted changes will be discarded on exit Entering configuration mode

root@# show | compare
                     ^
syntax error, expecting <command>.