### PR TITLE
issue587

### DIFF
--- a/ansible_collections/juniper/device/plugins/connection/pyez.py
+++ b/ansible_collections/juniper/device/plugins/connection/pyez.py
@@ -113,7 +113,7 @@ options:
     env:
     - name: ANSIBLE_PYEZ_CONSOLE
     vars:
-    - name: ansible_pyez_console    
+    - name: ansible_pyez_console
   private_key_file:
     description:
     - The private SSH key or certificate file used to authenticate to the remote device
@@ -202,7 +202,7 @@ options:
     vars:
     - name: ansible_pyez_ssh_config
     - name: ssh_config
-    
+
 """
 import pickle
 
@@ -453,7 +453,7 @@ class Connection(NetworkConnectionBase):
         """
         resp = self.dev.rpc.get_config(filter_xml, options, model, namespace, remove_ns, **kwarg)
         return etree.tostring(resp)
-   
+
     def get_rpc_resp(self,rpc, ignore_warning, format):
         """Execute rpc on the device and get response.
 
@@ -469,8 +469,8 @@ class Connection(NetworkConnectionBase):
         Fails:
             - If the RPC produces an exception.
         """
-        # data comes in JSON format, needs to be converted 
-        rpc_val = xmltodict.unparse(rpc) 
+        # data comes in JSON format, needs to be converted
+        rpc_val = xmltodict.unparse(rpc)
         rpc_val = rpc_val.encode('utf-8')
         parser = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
         rpc_etree = etree.fromstring(rpc_val, parser=parser)
@@ -478,7 +478,7 @@ class Connection(NetworkConnectionBase):
         if(format == 'json'):
             return resp
         return etree.tostring(resp)
-   
+
     def get_facts(self):
         """Get device facts.
         """
@@ -769,7 +769,7 @@ class Connection(NetworkConnectionBase):
             if action == 'reboot':
                 got = self.sw.reboot(in_min, at, all_re, None, vmhost, other_re)
             elif action == 'shutdown':
-                got = self.sw.poweroff(in_min, at, None, all_re, other_re)
+                got = self.sw.poweroff(in_min, at, None, all_re, other_re, vmhost)
             elif action == 'halt':
                 got = self.sw.halt(in_min, at, all_re, other_re)
             elif action == 'zeroize':

--- a/ansible_collections/juniper/device/plugins/modules/system.py
+++ b/ansible_collections/juniper/device/plugins/modules/system.py
@@ -39,7 +39,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-extends_documentation_fragment: 
+extends_documentation_fragment:
   - juniper_junos_common.connection_documentation
   - juniper_junos_common.logging_documentation
 module: system
@@ -81,7 +81,7 @@ options:
       - power_off
   at:
     description:
-      - The time at which to shutdown, halt, or reboot the system. 
+      - The time at which to shutdown, halt, or reboot the system.
       - >
         The value may be specified in one of the following ways:
       - B(now) - The action takes effect immediately.
@@ -353,7 +353,7 @@ def main():
                 if action == 'reboot':
                     got = junos_module.sw.reboot(in_min, at, all_re, None, vmhost, other_re)
                 elif action == 'shutdown':
-                    got = junos_module.sw.poweroff(in_min, at, None, all_re, other_re)
+                    got = junos_module.sw.poweroff(in_min, at, None, all_re, other_re, vmhost)
                 elif action == 'halt':
                     got = junos_module.sw.halt(in_min, at, all_re, other_re)
                 elif action == 'zeroize':


### PR DESCRIPTION
Devices with VMHOST only had reboot action supported and would throw an error if shutdown/poweroff was performed. The fix was to implement action:'shutdown' in the poweroff function with a check for vmhost=True and then call the respective rpc for shutting down vmhost devices on PyEz side. Also modify the function call for poweroff on the anisble side to support the same.