### PR TITLE
Issue:  commit_configuration API parameters are missing in ansible Py…

### DIFF
--- a/ansible_collections/juniper/device/plugins/connection/pyez.py
+++ b/ansible_collections/juniper/device/plugins/connection/pyez.py
@@ -302,7 +302,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.u
 )
 
 # Supported configuration modes
-CONFIG_MODE_CHOICES = ['exclusive', 'private']
+CONFIG_MODE_CHOICES = ['exclusive', 'private', 'dynamic', 'batch', 'ephemeral']
 
 
 class Connection(NetworkConnectionBase):
@@ -590,7 +590,7 @@ class Connection(NetworkConnectionBase):
                                    (type(responses), str(responses)))
         return results
 
-    def open_configuration(self, mode, ignore_warn=None):
+    def open_configuration(self, mode, ignore_warn=None, ephemeral_instance=None):
         """Open candidate configuration database in exclusive or private mode.
 
         Failures:
@@ -601,6 +601,8 @@ class Connection(NetworkConnectionBase):
         if self.config is None:
             if mode not in CONFIG_MODE_CHOICES:
                 raise AnsibleError("Invalid configuration mode: %s" % mode)
+            if mode != 'ephemeral' and ephemeral_instance is not None:
+                self.fail_json(msg='configuration mode ephemeral is required')
             if self.dev is None:
                 self.open()
             config = jnpr.junos.utils.config.Config(self.dev, mode=mode)
@@ -611,6 +613,23 @@ class Connection(NetworkConnectionBase):
                     self.dev.rpc.open_configuration(
                         private=True,
                         ignore_warning=ignore_warn)
+                elif config.mode == 'dynamic':
+                    self.dev.rpc.open_configuration(
+                        dynamic=True,
+                        ignore_warning=ignore_warn)
+                elif config.mode == 'batch':
+                    self.dev.rpc.open_configuration(
+                        batch=True,
+                        ignore_warning=ignore_warn)
+                elif config.mode == 'ephemeral':
+                    if ephemeral_instance is None:
+                        self.dev.rpc.open_configuration(
+                           ephemeral=True,
+                           ignore_warning=ignore_warn)
+                    else:
+                        self.dev.rpc.open_configuration(
+                           ephemeral_instance = ephemeral_instance,
+                           ignore_warning=ignore_warn)
             except (pyez_exception.ConnectError,
                     pyez_exception.RpcError) as ex:
                 raise AnsibleError('Unable to open the configuration in %s '
@@ -631,7 +650,7 @@ class Connection(NetworkConnectionBase):
             try:
                 if config.mode == 'exclusive':
                     config.unlock()
-                elif config.mode == 'private':
+                elif config.mode in ['batch', 'dynamic', 'private', 'ephemeral']:
                     self.dev.rpc.close_configuration()
                 self.queue_message("log", "Configuration closed.")
             except (pyez_exception.ConnectError,
@@ -723,7 +742,7 @@ class Connection(NetworkConnectionBase):
             if config is not None:
                 self.config.load(config, **load_args)
             else:
-                self.queue_message("log", "Load args %s.", str(load_args))
+                self.queue_message("log", "Load args %s." %str(load_args))
                 self.config.load(**load_args)
             self.queue_message("log", "Configuration loaded.")
         except (self.pyez_exception.RpcError,
@@ -732,7 +751,8 @@ class Connection(NetworkConnectionBase):
                                (str(ex)))
 
     def commit_configuration(self, ignore_warning=None, comment=None,
-                             confirmed=None):
+                             confirmed=None, timeout=30, full=False,
+                             force_sync=False, sync=False):
         """Commit the candidate configuration.
         Assumes the configuration is already opened.
 
@@ -747,7 +767,11 @@ class Connection(NetworkConnectionBase):
         try:
             self.config.commit(ignore_warning=ignore_warning,
                                comment=comment,
-                               confirm=confirmed)
+                               confirm=confirmed,
+                               timeout=timeout,
+                               full=full,
+                               force_sync=force_sync,
+                               sync=sync)
             self.queue_message("log", "Configuration committed.")
         except (self.pyez_exception.RpcError,
                 self.pyez_exception.ConnectError) as ex:

--- a/ansible_collections/juniper/device/plugins/connection/pyez.py
+++ b/ansible_collections/juniper/device/plugins/connection/pyez.py
@@ -602,13 +602,9 @@ class Connection(NetworkConnectionBase):
             if mode not in CONFIG_MODE_CHOICES:
                 raise AnsibleError("Invalid configuration mode: %s" % mode)
             if mode != 'ephemeral' and ephemeral_instance is not None:
-<<<<<<< HEAD
-                self.fail_json(msg='configuration mode ephemeral is required')
-=======
-                self.fail_json(msg='Ephemeral instance is specified while the mode
-                                   is not ephemeral. Specify the mode as 'ephemeral'
-                                   or do not specify the instance.')
->>>>>>> 7236406 (Issue:  commit_configuration API parameters are missing in ansible PyEZ connection API  and also formatted error was noticed.)
+                self.fail_json(msg='Ephemeral instance is specified while the mode '
+                                   'is not ephemeral. Specify the mode as ephemeral '
+                                   'or do not specify the instance.')
             if self.dev is None:
                 self.open()
             config = jnpr.junos.utils.config.Config(self.dev, mode=mode)

--- a/ansible_collections/juniper/device/plugins/connection/pyez.py
+++ b/ansible_collections/juniper/device/plugins/connection/pyez.py
@@ -602,7 +602,13 @@ class Connection(NetworkConnectionBase):
             if mode not in CONFIG_MODE_CHOICES:
                 raise AnsibleError("Invalid configuration mode: %s" % mode)
             if mode != 'ephemeral' and ephemeral_instance is not None:
+<<<<<<< HEAD
                 self.fail_json(msg='configuration mode ephemeral is required')
+=======
+                self.fail_json(msg='Ephemeral instance is specified while the mode
+                                   is not ephemeral. Specify the mode as 'ephemeral'
+                                   or do not specify the instance.')
+>>>>>>> 7236406 (Issue:  commit_configuration API parameters are missing in ansible PyEZ connection API  and also formatted error was noticed.)
             if self.dev is None:
                 self.open()
             config = jnpr.junos.utils.config.Config(self.dev, mode=mode)

--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1165,7 +1165,9 @@ class JuniperJunosModule(AnsibleModule):
             if mode not in CONFIG_MODE_CHOICES:
                 self.fail_json(msg='Invalid configuration mode: %s' % (mode))
             if mode != 'ephemeral' and ephemeral_instance is not None:
-                self.fail_json(msg='configuration mode ephemeral is required')
+                self.fail_json(msg='Ephemeral instance is specified while the mode
+                               is not ephemeral.Specify the mode as 'ephemeral' or
+                               do not specify the instance.')
             if self.dev is None:
                 self.open()
             config = jnpr.junos.utils.config.Config(self.dev, mode=mode)

--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1165,9 +1165,9 @@ class JuniperJunosModule(AnsibleModule):
             if mode not in CONFIG_MODE_CHOICES:
                 self.fail_json(msg='Invalid configuration mode: %s' % (mode))
             if mode != 'ephemeral' and ephemeral_instance is not None:
-                self.fail_json(msg='Ephemeral instance is specified while the mode
-                               is not ephemeral.Specify the mode as 'ephemeral' or
-                               do not specify the instance.')
+                self.fail_json(msg='Ephemeral instance is specified while the mode '
+                               'is not ephemeral.Specify the mode as ephemeral or '
+                               'do not specify the instance.')
             if self.dev is None:
                 self.open()
             config = jnpr.junos.utils.config.Config(self.dev, mode=mode)

--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1542,7 +1542,7 @@ class JuniperJunosModule(AnsibleModule):
             - An error returned from committing the configuration.
         """
         if self.conn_type != "local":
-            self._pyez_conn.commit_configuration(ignore_warning, comment, timeout, confirmed)
+            self._pyez_conn.commit_configuration(ignore_warning, comment, timeout, confirmed, full, sync, force_sync)
             return
 
         if self.dev is None or self.config is None:


### PR DESCRIPTION
Issue:  
Commit_configuration API parameters are missing in ansible PyEZ connection API  and also formatted error was noticed.
This impacts committing the configuration using an ansible PyEZ connection.

Fix:
Supported valid parameter in commit_configuration API parameter.
Fixed format string issue.
Fixed configuration mode support for ansible PyEZ connection.