### PR TITLE
Fix for Object of type function is not JSON serializable

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/software.py
+++ b/ansible_collections/juniper/device/plugins/modules/software.py
@@ -689,7 +689,10 @@ def main():
             install_params['package'] = remote_filename
         if remote_dir is not None:
             install_params['remote_path'] = remote_dir
-        install_params['progress'] = define_progress_callback(junos_module)
+        if junos_module.conn_type != "local":
+            install_params['progress'] = True
+        else:
+            install_params['progress'] = define_progress_callback(junos_module)
         install_params['cleanfs'] = cleanfs
         install_params['no_copy'] = no_copy
         install_params['timeout'] = install_timeout

--- a/tests/ansible.cfg
+++ b/tests/ansible.cfg
@@ -3,3 +3,6 @@
 hash_behaviour=merge
 roles_path = ~/.ansible/roles
 
+[persistent_connection]
+command_timeout = 300
+


### PR DESCRIPTION
Fix for JSON encoder error “TypeError: Object of type function is not JSON serializable”