### PR TITLE
Updated commit_configuration API  parameter for PyEZ connection.

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1544,7 +1544,13 @@ class JuniperJunosModule(AnsibleModule):
             - An error returned from committing the configuration.
         """
         if self.conn_type != "local":
-            self._pyez_conn.commit_configuration(ignore_warning, comment, timeout, confirmed, full, sync, force_sync)
+            self._pyez_conn.commit_configuration(ignore_warning=ignore_warning,
+                                                 comment=comment,
+                                                 confirm=confirmed,
+                                                 timeout=timeout,
+                                                 full=full,
+                                                 force_sync=force_sync,
+                                                 sync=sync)
             return
 
         if self.dev is None or self.config is None:


### PR DESCRIPTION
### Issue: 
PyEZ connection commit_configuration API parameter data are mismatched. So it impacts commit RPC when the commit operation is performed.

### Fix:
I updated the valid parameter in commit_configuration API  The output log is below.

```
#################
    - name: "Execute set configuration"
      config:
        load: "set"
        format: "set"
        lines: 'set system login message "Login"'
        comment: "comment"
      register: test1
      tags: [ test1 ]
```


```
May  8 04:34:23 [NETCONF] - [26690] Incoming: <?xml version="1.0" encoding="UTF-8"?><nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="urn:uuid:6f6d5aa0-d23a-4e5e-b1cb-2fd2b080b23e"><commit-configuration><log>comment</log></commit-configuration></nc:rpc>]]>]]>
```
