### PR TITLE
Fix for issue #580

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1497,7 +1497,8 @@ class JuniperJunosModule(AnsibleModule):
             config = '\n'.join(map(lambda line: line.rstrip('\n'), lines))
             self.logger.debug("Loading the supplied configuration.")
         if src is not None:
-            load_args['path'] = src
+            abs_path_src = os.path.abspath(src)  # For PyEZ persistent
+            load_args['path'] = abs_path_src
             self.logger.debug("Loading the configuration from: %s.", src)
         if template is not None:
             load_args['template_path'] = template


### PR DESCRIPTION
For persistent PyEZ connection , if we specify path of the config file as relative path , it fails with following error 
'data': \"Failure loading the configuraton: [Errno 2] No such file or directory: 'junos.conf'

So, added code to convert the path to absolute path of src file .