### PR TITLE
Fix for the issue #607

### DIFF
--- a/ansible_collections/juniper/device/plugins/connection/pyez.py
+++ b/ansible_collections/juniper/device/plugins/connection/pyez.py
@@ -766,6 +766,8 @@ class Connection(NetworkConnectionBase):
         Failures:
             - An error returned from committing the configuration.
         """
+        if self.dev.timeout:
+            timeout = self.dev.timeout
         try:
             self.config.commit(ignore_warning=ignore_warning,
                                comment=comment,

--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1541,6 +1541,10 @@ class JuniperJunosModule(AnsibleModule):
         Failures:
             - An error returned from committing the configuration.
         """
+        if self.conn_type == "local":
+            if self.dev.timeout:
+                timeout = self.dev.timeout
+
         if self.conn_type != "local":
             self._pyez_conn.commit_configuration(ignore_warning=ignore_warning,
                                                  comment=comment,

--- a/ansible_collections/juniper/device/plugins/modules/config.py
+++ b/ansible_collections/juniper/device/plugins/modules/config.py
@@ -942,6 +942,9 @@ def main():
                            type='int',
                            aliases=['confirm'],
                            default=None),
+            timeout=dict(required=False,
+                           type='int',
+                           default=30),
             comment=dict(required=False,
                          type='str',
                          default=None),
@@ -995,6 +998,7 @@ def main():
     commit_sync = junos_module.params.get('commit_sync')
     commit_force_sync = junos_module.params.get('commit_force_sync')
     confirmed = junos_module.params.get('confirmed')
+    timeout = junos_module.params.get('timeout')
     comment = junos_module.params.get('comment')
     check_commit_wait = junos_module.params.get('check_commit_wait')
     model = junos_module.params.get('model')
@@ -1227,6 +1231,7 @@ def main():
             junos_module.commit_configuration(ignore_warning=ignore_warning,
                                               comment=comment,
                                               confirmed=confirmed,
+                                              timeout=timeout,
                                               full=commit_full,
                                               sync=commit_sync,
                                               force_sync=commit_force_sync)

--- a/tests/pb.juniper_junos_config.yml
+++ b/tests/pb.juniper_junos_config.yml
@@ -141,3 +141,19 @@
       ansible.builtin.assert:
         that:
           test8.changed == False
+################
+    - name: Test commit timeout .
+      juniper.device.config:
+        load: 'merge'
+        lines:
+          - "set system host-name {{ inventory_hostname }}.foo"
+        comment: "Append .foo to the hostname"
+        timeout: 300
+      register: test2
+      ignore_errors: true
+      tags: [test2]
+
+    - name: Check TEST 2
+      ansible.builtin.assert:
+        that:
+          - test2.diff_lines


### PR DESCRIPTION
added timeout parameter and passed it to commit_configuration
example:
    - name: "Load configuration from a local file and commit"
      juniper.device.config:
        load: "merge"
        src: "junos_jsnapy/junos.conf"
        confirmed: 20
        timeout: 120
