### PR TITLE
fix for issue #672 to handle float values

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1686,8 +1686,7 @@ class JuniperJunosModule(AnsibleModule):
         packet_loss = 100
         if results['packet_loss'] is not None:
             try:
-                packet_loss = float(results['packet_loss'])
-                packet_loss = round(packet_loss)
+                packet_loss = round(float(results['packet_loss']))
             except ValueError:
                 results['msg'] = 'Packet loss %s not an integer. ' \
                                  'Response: %s' % \

--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1686,7 +1686,8 @@ class JuniperJunosModule(AnsibleModule):
         packet_loss = 100
         if results['packet_loss'] is not None:
             try:
-                packet_loss = int(results['packet_loss'])
+                packet_loss = float(results['packet_loss'])
+                packet_loss = round(packet_loss)
             except ValueError:
                 results['msg'] = 'Packet loss %s not an integer. ' \
                                  'Response: %s' % \


### PR DESCRIPTION
for ping command response,  packet loss values might of type float values, so added the code to read the value in float and round  of it to nearest  integer value before comparing it with acceptable_packet_loss.