### PR TITLE
Fix for issue #674 syntax warnings

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -1812,7 +1812,7 @@ class JuniperJunosModule(AnsibleModule):
         """
         Computes the MD5 checksum value on the local package file.
         :param str package:
-            File-path to the package (\*.tgz) file on the local server
+            File-path to the package (tgz) file on the local server
         :returns: MD5 checksum (str)
         :raises IOError: when **package** file does not exist
         """

--- a/ansible_collections/juniper/device/plugins/modules/software.py
+++ b/ansible_collections/juniper/device/plugins/modules/software.py
@@ -423,7 +423,7 @@ def parse_version_from_filename(filename):
             # Assumes the version string will be prefixed by -.
             # Assume major version will begin with two digits followed by dot.
             # Assume the version string ends with the last digit in filename.
-            match = re.search('-(\d{2}\..*\d).*', filename)
+            match = re.search(r'-(\d{2}\..*\d).*', filename)
             if match is not None:
                 return match.group(1)
     # Not a known Junos package name.


### PR DESCRIPTION
Fixed SyntaxWarning: invalid escape sequence emitted on Python 3.12 version.