### PR TITLE
support to save the failed tests to dest_dir for local and pyez connection

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/jsnapy.py
+++ b/ansible_collections/juniper/device/plugins/modules/jsnapy.py
@@ -392,7 +392,8 @@ def main():
     # If we made it this far, it's success.
     results['failed'] = False
 
-    # To write failed test details to dest_dir
+    # To save the failed test_name details to dest_dir
+    # for connection local
     if action in ('snapcheck', 'check'):
         if junos_module.conn_type == "local":
             for response in responses:
@@ -402,6 +403,16 @@ def main():
                         if (('test_name' in data1.keys()) and ('result' in data1.keys())):
                             if data1['result'] == False:
                                 test_name = str(data1['test_name']) + "_" + str(data1['result'])
+                                text_msg = str(data)
+                                junos_module.save_text_output(test_name, "text", text_msg)
+        else:
+            # For connection pyez
+            for res in results["test_results"]:
+                for data in results['test_results'][res]:
+                    for key, value in data.items():
+                        if (('test_name' in data.keys()) and ('result' in data.keys())):
+                            if data['result'] == False:
+                                test_name = str(data['test_name']) + "_" + str(data['result'])
                                 text_msg = str(data)
                                 junos_module.save_text_output(test_name, "text", text_msg)
 

--- a/ansible_collections/juniper/device/plugins/modules/jsnapy.py
+++ b/ansible_collections/juniper/device/plugins/modules/jsnapy.py
@@ -222,6 +222,10 @@ def main():
             config_file=dict(required=False,
                              type='path',
                              default=None),
+            dest_dir=dict(required=False,
+                          type='path',
+                          aliases=['destination_dir', 'destdir'],
+                          default=None),
             dir=dict(required=False,
                      type='path',
                      aliases=['directory'],
@@ -387,6 +391,19 @@ def main():
 
     # If we made it this far, it's success.
     results['failed'] = False
+
+    # To write failed test details to dest_dir
+    if action in ('snapcheck', 'check'):
+        if junos_module.conn_type == "local":
+            for response in responses:
+                results = response.test_details
+                for cmd, data in results.items():
+                    for data1 in data:
+                        if (('test_name' in data1.keys()) and ('result' in data1.keys())):
+                            if data1['result'] == False:
+                                test_name = str(data1['test_name']) + "_" + str(data1['result'])
+                                text_msg = str(data)
+                                junos_module.save_text_output(test_name, "text", text_msg)
 
     junos_module.exit_json(**results)
 

--- a/ansible_collections/juniper/device/plugins/modules/jsnapy.py
+++ b/ansible_collections/juniper/device/plugins/modules/jsnapy.py
@@ -243,6 +243,7 @@ def main():
     test_files = junos_module.params.get('test_files')
     config_file = junos_module.params.get('config_file')
     dir = junos_module.params.get('dir')
+    dest_dir = junos_module.params.get('dest_dir')
 
     # Initialize the results. Assume failure until we know otherwise.
     results = {'msg': '',
@@ -394,27 +395,28 @@ def main():
 
     # To save the failed test_name details to dest_dir
     # for connection local
-    if action in ('snapcheck', 'check'):
-        if junos_module.conn_type == "local":
-            for response in responses:
-                results = response.test_details
-                for cmd, data in results.items():
-                    for data1 in data:
-                        if (('test_name' in data1.keys()) and ('result' in data1.keys())):
-                            if data1['result'] == False:
-                                test_name = str(data1['test_name']) + "_" + str(data1['result'])
-                                text_msg = str(data)
-                                junos_module.save_text_output(test_name, "text", text_msg)
-        else:
-            # For connection pyez
-            for res in results["test_results"]:
-                for data in results['test_results'][res]:
-                    for key, value in data.items():
-                        if (('test_name' in data.keys()) and ('result' in data.keys())):
-                            if data['result'] == False:
-                                test_name = str(data['test_name']) + "_" + str(data['result'])
-                                text_msg = str(data)
-                                junos_module.save_text_output(test_name, "text", text_msg)
+    if dest_dir is not None:
+        if action in ('snapcheck', 'check'):
+            if junos_module.conn_type == "local":
+                for response_loc in responses:
+                    results_loc = response_loc.test_details
+                    for cmd, data in results.items():
+                        for data1 in data:
+                            if (('test_name' in data1.keys()) and ('result' in data1.keys())):
+                                if data1['result'] == False:
+                                    test_name = str(data1['test_name']) + "_" + str(data1['result'])
+                                    text_msg = str(data)
+                                    junos_module.save_text_output(test_name, "text", text_msg)
+            else:
+                # For connection pyez
+                for res in results["test_results"]:
+                    for data in results['test_results'][res]:
+                        for key, value in data.items():
+                            if (('test_name' in data.keys()) and ('result' in data.keys())):
+                                if data['result'] == False:
+                                    test_name = str(data['test_name']) + "_" + str(data['result'])
+                                    text_msg = str(data)
+                                    junos_module.save_text_output(test_name, "text", text_msg)
 
     junos_module.exit_json(**results)
 


### PR DESCRIPTION
Added to support to save the failed  test result files to a user specified directory - dest_dir: "{{ backup_dir }}"
with filename format for issue #676
```
<hostname>_<test_name>.text

Ex:

    - name: "Check after PRE - POST check"
      juniper.device.jsnapy:
        dir: "{{ JSNAPy_dir }}"
        test_files:
          - system_util_baseline.yml
          - verify_ospf_neighbor.yml
          - test_chassis_alarms.yml
        logfile: "{{tlogfile}}"
        action: "snapcheck"
        dest_dir: "{{ backup_dir }}"
      register: test_check
      tags:
        - jsnapy

test file: system_util_baseline.yml

test details:

cat jsnapy_TEST_FILES/system_util_baseline.yml 
tests_include:
  - check_core_dumps
  - check_system_memory_usage
    #- check_system_resource_usage

check_core_dumps:
  - command: show system core-dumps
  - iterate:
      xpath: multi-routing-engine-item
      id: re-name
      tests:
        - no-diff: directory-list/output

check_system_memory_usage:
  - command: show system memory
  - iterate:
      xpath: multi-routing-engine-item 
      id: re-name
      tests:
        # - delta: system-memory-free, 10%
        - in-range: system-memory-information/system-memory-summary-information/system-memory-free-percent, 70,99

Failed test: check_system_memory_usage

backup_dir/x.x.x.x_check_system_memory_usage_False.text

cat backup_dir/x.x.x.x_check_system_memory_usage_False.text 
[{'xpath': 'multi-routing-engine-item', 'testoperation': 'in-range', 'passed': [], 'failed': [{'id': {}, 'pre': {}, 'post': {}, 'actual_node_value': None, 'xpath_error': True}], 'test_name': 'check_system_memory_usage', 'node_name': 'system-memory-information/system-memory-summary-information/system-memory-free-percent', 'expected_node_value': [70.0, 99.0], 'result': False, 'count': {'pass': 0, 'fail': 1}}]

```