### PR TITLE
config_file and pyez_conn issue #671

### DIFF
--- a/ansible_collections/juniper/device/plugins/connection/pyez.py
+++ b/ansible_collections/juniper/device/plugins/connection/pyez.py
@@ -538,7 +538,7 @@ class Connection(NetworkConnectionBase):
         return self.dev.rpc.set_chassis_cluster_disable(
                             reboot=True, normalize=True)
 
-    def invoke_jsnapy(self, data, action):
+    def invoke_jsnapy(self, data, action, folder=None):
         """invoke jsnapy for persistent connection.
         """
         try:
@@ -549,19 +549,23 @@ class Connection(NetworkConnectionBase):
                 responses = jsa.check(data=data,
                                       dev=self.dev,
                                       pre_file='PRE',
-                                      post_file='POST')
+                                      post_file='POST',
+                                      folder=folder)
             elif action == 'snapcheck':
                 responses = jsa.snapcheck(data=data,
                                           dev=self.dev,
-                                          pre_file='PRE')
+                                          pre_file='PRE',
+                                          folder=folder)
             elif action == 'snap_pre':
                 responses = jsa.snap(data=data,
                                      dev=self.dev,
-                                     file_name='PRE')
+                                     file_name='PRE',
+                                     folder=folder)
             elif action == 'snap_post':
                 responses = jsa.snap(data=data,
                                      dev=self.dev,
-                                     file_name='POST')
+                                     file_name='POST',
+                                     folder=folder)
             else:
                 raise AnsibleError("Unexpected action: %s." % (action))
             self.queue_message("vvvv", 'The %s action executed successfully' % action)

--- a/ansible_collections/juniper/device/plugins/modules/jsnapy.py
+++ b/ansible_collections/juniper/device/plugins/modules/jsnapy.py
@@ -285,36 +285,44 @@ def main():
         if action == 'check':
             if junos_module.conn_type != "local":
                 responses = junos_module._pyez_conn.invoke_jsnapy(data=data,
-                                                                  action='check')
+                                                                  action='check',
+                                                                  folder=dir)
             else:
                 responses = jsa.check(data=data,
                                       dev=junos_module.dev,
                                       pre_file='PRE',
-                                      post_file='POST')
+                                      post_file='POST',
+                                      folder=dir)
         elif action == 'snapcheck':
             if junos_module.conn_type != "local":
                 responses = junos_module._pyez_conn.invoke_jsnapy(data=data,
-                                                                  action='snapcheck')
+                                                                  action='snapcheck',
+                                                                  folder=dir)
             else:
                 responses = jsa.snapcheck(data=data,
                                           dev=junos_module.dev,
-                                          pre_file='PRE')
+                                          pre_file='PRE',
+                                          folder=dir)
         elif action == 'snap_pre':
             if junos_module.conn_type != "local":
                 responses = junos_module._pyez_conn.invoke_jsnapy(data=data,
-                                                                  action='snap_pre')
+                                                                  action='snap_pre',
+                                                                  folder=dir)
             else:
                 responses = jsa.snap(data=data,
                                      dev=junos_module.dev,
-                                     file_name='PRE')
+                                     file_name='PRE',
+                                     folder=dir)
         elif action == 'snap_post':
             if junos_module.conn_type != "local":
                 responses = junos_module._pyez_conn.invoke_jsnapy(data=data,
-                                                                  action='snap_post')
+                                                                  action='snap_post',
+                                                                  folder=dir)
             else:
                 responses = jsa.snap(data=data,
                                      dev=junos_module.dev,
-                                     file_name='POST')
+                                     file_name='POST',
+                                     folder=dir)
         else:
             junos_module.fail_json(msg="Unexpected action: %s." % (action))
         junos_module.logger.debug('The %s action executed successfully.',


### PR DESCRIPTION
Fix for jsnapy module execution with combination of config_file and juniper.device.pyez , when test yaml files are copied under custom_directory .

  vars:
    JSNAPy_dir: "{{ playbook_dir }}/jsnapy_TEST_FILES"

    - name: "Collect Pre Snapshot"
      juniper.device.jsnapy:
        dir: "{{ JSNAPy_dir }}"
        config_file: jsnapy_main.yml
        logfile: "{{ tlogfile }}"
        action: "snap_pre"
      register: test_pre
      ignore_errors: true

cat jsnapy_TEST_FILES/jsnapy_main.yml
  tests:
    - test_chassis_alarms.yml

cat jsnapy_TEST_FILES/testfiles/test_chassis_alarms.yml 
tests_include:
 - test_chassis_alarm_check
# - test_chassis_alarm_check_collect_text

test_chassis_alarm_check:
  - command: show chassis alarms

