### PR TITLE
Fix galaxy.yml "documentation" link

### DIFF
--- a/ansible_collections/juniper/device/galaxy.yml
+++ b/ansible_collections/juniper/device/galaxy.yml
@@ -41,7 +41,7 @@ dependencies: {}
 repository: https://github.com/Juniper/ansible-junos-stdlib
 
 # The URL to any online docs
-documentation: https://junos-ansible-modules.readthedocs.io
+documentation: https://ansible-juniper-collection.readthedocs.io/
 
 # The URL to the homepage of the collection/project
 homepage: https://github.com/Juniper/ansible-junos-stdlib


### PR DESCRIPTION
Just fixing the link!

Why? 
* It was accidentally pointing to [readthedocs site for the "Juniper.junos Ansible Modules"](https://junos-ansible-modules.readthedocs.io/en/2.4.0/)
* It should instead point to [readthedocs site for the "juniper.device Ansible Modules"](https://ansible-juniper-collection.readthedocs.io)

Importantly, I hope this change will fix the "Docs site" hyperlink at [the galaxy.ansible.com page for this Ansible Collection](https://galaxy.ansible.com/ui/repo/published/juniper/device/docs/), seen in screenshot below:

![image](https://github.com/user-attachments/assets/1f97e531-5d02-4f31-88e2-eabd84fb9f19)
