### PR TITLE
Enhanced file_copy module

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/juniper_junos_common.py
@@ -62,12 +62,19 @@ from ansible.module_utils.six import string_types
 
 # Ansible imports
 from ansible.module_utils.connection import Connection
+
 try:
     from jnpr.junos.utils.sw import SW
 
     HAS_PYEZ_SW = True
 except ImportError:
     HAS_PYEZ_SW = False
+try:
+    from jnpr.junos.utils.ftp import FTP
+
+    HAS_PYEZ_FTP = True
+except ImportError:
+    HAS_PYEZ_FTP = False
 try:
     from jnpr.junos.utils.scp import SCP
 
@@ -586,7 +593,7 @@ class JuniperJunosModule(AnsibleModule):
         min_jsnapy_version=None,
         min_jxmlease_version=None,
         min_yaml_version=None,
-        **kwargs
+        **kwargs,
     ):
         """Initialize a new JuniperJunosModule instance.
 
@@ -1907,12 +1914,12 @@ class JuniperJunosModule(AnsibleModule):
         model=None,
         namespace=None,
         remove_ns=True,
-        **kwarg
+        **kwarg,
     ):
         response = self._pyez_conn.get_config(
             filter_xml, options, model, namespace, remove_ns, **kwarg
         )
-        if options['format'] == 'json':
+        if options["format"] == "json":
             return response
         else:
             return self.etree.fromstring(response)
@@ -1984,6 +1991,10 @@ class JuniperJunosModule(AnsibleModule):
         return checksum
 
     def scp_file_copy_put(self, local_file, remote_file):
+        """
+        Transfers a file from the local system to a remote destination using SCP,
+        only if the file is not already present or differs on the remote side.
+        """
         self.logger.info("Computing local MD5 checksum on: {0}".format(local_file))
         local_checksum = self.local_md5(local_file, "put")
         self.logger.info("Local checksum: {0}".format(local_checksum))
@@ -2018,7 +2029,87 @@ class JuniperJunosModule(AnsibleModule):
             self.logger.info(status)
             return [status, False]
 
+    def scp_file_copy_put_without_checksum(self, local_file, remote_file):
+        """
+        Transfers a file from the local system to a remote destination using SCP
+        without performing MD5 checksum verification.
+        """
+        if self.conn_type == "local":
+            try:
+                with SCP(self.dev, progress=True) as scp1:
+                    scp1.put(local_file, remote_file)
+                return ["File pushed OK", True]
+            except Exception as e:
+                return [f"Error: {str(e)}", False]
+        else:
+            self._pyez_conn.scp_file_copy_put(local_file, remote_file)
+            return ["File pushed OK", True]
+
+    def ftp_file_copy_put(self, local_file, remote_file):
+        """
+        Transfers a file from the local system to a remote destination using
+        ftp, only if the file is not already present or differs on the remote side.
+        """
+        self.logger.info("Computing local MD5 checksum on: {0}".format(local_file))
+        local_checksum = self.local_md5(local_file, "put")
+        self.logger.info("Local checksum: {0}".format(local_checksum))
+        remote_checksum = self.remote_md5(remote_file, "put")
+        if remote_checksum == "no_file" or remote_checksum != local_checksum:
+            status = "File not present, need to transfer"
+            self.logger.info(status)
+            if self.conn_type == "local":
+                with FTP(self.dev) as ftp:
+                    ftp.put(local_file, remote_file)
+            else:
+                self._pyez_conn.ftp_file_copy_put(local_file, remote_file)
+            self.logger.info(
+                "computing remote MD5 checksum on: {0}".format(remote_file)
+            )
+            remote_checksum = self.remote_md5(remote_file, "put")
+            self.logger.info("Remote checksum: {0}".format(remote_checksum))
+            if remote_checksum != local_checksum:
+                status = "Transfer failed (different MD5 between local and remote) {0} | {1}".format(
+                    local_checksum, remote_checksum
+                )
+                self.logger.error(status)
+                self.fail_json(msg=status)
+                return [status, False]
+            else:
+                status = "File pushed OK"
+                self.logger.info("Checksum check passed.")
+                self.logger.info(status)
+                return [status, True]
+        else:
+            status = "File already present, skipping the scp"
+            self.logger.info(status)
+            return [status, False]
+
+    def ftp_file_copy_put_without_checksum(self, local_file, remote_file):
+        """
+        Transfers a file from the local system to a remote destination using
+        FTP without performing MD5 checksum verification.
+        """
+        if self.conn_type == "local":
+            try:
+                with FTP(self.dev) as ftp:
+                    result = ftp.put(local_file, remote_file)
+                if result:
+                    return ["File pushed OK", True]
+                else:
+                    return ["Transfer failed", False]
+            except Exception as e:
+                return [f"Error: {str(e)}", False]
+        else:
+            result = self._pyez_conn.ftp_file_copy_put(local_file, remote_file)
+            if result:
+                return ["File pushed OK", True]
+            else:
+                return ["Transfer failed", False]
+
     def scp_file_copy_get(self, remote_file, local_file):
+        """
+        Retrieves a file from a remote system using SCP, verifying integrity via MD5 checksum.
+        """
         self.logger.info("Computing remote MD5 checksum on: {0}".format(remote_file))
         remote_checksum = self.remote_md5(remote_file, "get")
         self.logger.info("Remote checksum: {0}".format(remote_checksum))
@@ -2050,3 +2141,75 @@ class JuniperJunosModule(AnsibleModule):
             status = "File already present, skipping the scp"
             self.logger.info(status)
             return [status, False]
+
+    def scp_file_copy_get_without_checksum(self, remote_file, local_file):
+        """
+        Retrieves a file from a remote system using SCP, without checksum.
+        """
+        if self.conn_type == "local":
+            try:
+                with SCP(self.dev, progress=True) as scp1:
+                    scp1.get(remote_file, local_file)
+                return ["File pushed OK", True]
+            except Exception as e:
+                return [f"Error: {str(e)}", False]
+        else:
+            self._pyez_conn.scp_file_copy_get(remote_file, local_file)
+            return ["File pushed OK", True]
+
+    def ftp_file_copy_get(self, remote_file, local_file):
+        """
+        Retrieves a file from a remote system using FTP, verifying integrity via MD5 checksum.
+        """
+        self.logger.info("Computing remote MD5 checksum on: {0}".format(remote_file))
+        remote_checksum = self.remote_md5(remote_file, "get")
+        self.logger.info("Remote checksum: {0}".format(remote_checksum))
+        local_checksum = self.local_md5(local_file, "get")
+        if local_checksum == "no_file" or local_checksum != remote_checksum:
+            status = "File not present, need to transfer"
+            self.logger.info(status)
+            if self.conn_type == "local":
+                with FTP(self.dev) as ftp:
+                    ftp.get(remote_file, local_file)
+            else:
+                self._pyez_conn.ftp_file_copy_get(remote_file, local_file)
+            self.logger.info("computing local MD5 checksum on: {0}".format(local_file))
+            local_checksum = self.local_md5(local_file, "get")
+            self.logger.info("Local checksum: {0}".format(local_checksum))
+            if remote_checksum != local_checksum:
+                status = "Transfer failed (different MD5 between local and remote) {0} | {1}".format(
+                    local_checksum, remote_checksum
+                )
+                self.logger.error(status)
+                self.fail_json(msg=status)
+                return [status, False]
+            else:
+                status = "File pushed OK"
+                self.logger.info("Checksum check passed.")
+                self.logger.info(status)
+                return [status, True]
+        else:
+            status = "File already present, skipping the scp"
+            self.logger.info(status)
+            return [status, False]
+
+    def ftp_file_copy_get_without_checksum(self, remote_file, local_file):
+        """
+        Retrieves a file from a remote system using FTP, without checksum.
+        """
+        if self.conn_type == "local":
+            try:
+                with FTP(self.dev) as ftp:
+                    result = ftp.get(remote_file, local_file)
+                if result:
+                    return ["File pushed OK", True]
+                else:
+                    return ["Transfer failed", False]
+            except Exception as e:
+                return [f"Error: {str(e)}", False]
+        else:
+            result = self._pyez_conn.ftp_file_copy_get(remote_file, local_file)
+        if result:
+            return ["File pushed OK", True]
+        else:
+            return ["Transfer failed", False]

--- a/tests/pb.juniper_junos_file.yml
+++ b/tests/pb.juniper_junos_file.yml
@@ -3,40 +3,239 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Creates file log.txt
+    - name: Creates file scp_log.txt
       ansible.builtin.file:
-        path: /var/tmp/log.txt
+        path: /var/tmp/scp_log.txt
         state: touch
         mode: '0644'
 
-    - name: Delete local file log.txt
+    - name: Creates file ftp_log.txt
       ansible.builtin.file:
-        path: /tmp/log.txt
+        path: /var/tmp/ftp_log.txt
+        state: touch
+        mode: '0644'
+
+    - name: Creates file default_log.txt
+      ansible.builtin.file:
+        path: /var/tmp/default_log.txt
+        state: touch
+        mode: '0644'
+
+    - name: Creates file transfer_log.txt
+      ansible.builtin.file:
+        path: /var/tmp/transfer_log.txt
+        state: touch
+        mode: '0644'
+
+    - name: Creates file checksum_log.txt
+      ansible.builtin.file:
+        path: /var/tmp/checksum_log.txt
+        state: touch
+        mode: '0644'
+
+    - name: Delete local file scp_log.txt
+      ansible.builtin.file:
+        path: /tmp/scp_log.txt
         state: absent
 
-    - name: "File copy"
+    - name: Delete local file ftp_log.txt
+      ansible.builtin.file:
+        path: /tmp/ftp_log.txt
+        state: absent
+
+    - name: Delete local file default_log.txt
+      ansible.builtin.file:
+        path: /tmp/default_log.txt
+        state: absent
+
+    - name: Delete local file local_log.txt
+      ansible.builtin.file:
+        path: /tmp/local_log.txt
+        state: absent
+
+    - name: Delete local file checksum_log.txt
+      ansible.builtin.file:
+        path: /tmp/checksum_log.txt
+        state: absent
+
+    - name: "File copy ftp put"
       juniper.device.file_copy:
+        protocol: ftp
         local_dir: /var/tmp
         remote_dir: /var/log
-        file: log.txt
+        file: ftp_log.txt
         action: put
       register: test1
       ignore_errors: true
 
-    - name: Check file copy put
+    - name: Check ftp file copy put
       ansible.builtin.assert:
         that:
           - test1.msg == 'File pushed OK'
 
-    - name: "File copy get"
+    - name: "File copy ftp get"
       juniper.device.file_copy:
+        protocol: ftp
         local_dir: /tmp
         remote_dir: /var/log
-        file: log.txt
+        file: ftp_log.txt
         action: get
       register: test2
 
-    - name: Check file copy get
+    - name: Check ftp file copy get
       ansible.builtin.assert:
         that:
           - test2.msg == 'File pushed OK'
+
+    - name: "File copy scp put"
+      juniper.device.file_copy:
+        protocol: scp
+        local_dir: /var/tmp
+        remote_dir: /var/log
+        file: scp_log.txt
+        action: put
+      register: test1
+      ignore_errors: true
+
+    - name: Check scp file copy put
+      ansible.builtin.assert:
+        that:
+          - test1.msg == 'File pushed OK'
+
+    - name: "File copy get by scp"
+      juniper.device.file_copy:
+        protocol: scp
+        local_dir: /tmp
+        remote_dir: /var/log
+        file: scp_log.txt
+        action: get
+      register: test2
+
+    - name: Check scp file copy get
+      ansible.builtin.assert:
+        that:
+          - test2.msg == 'File pushed OK'
+
+    - name: "File copy put by default scp"
+      juniper.device.file_copy:
+        local_dir: /var/tmp
+        remote_dir: /var/log
+        file: default_log.txt
+        action: put
+      register: test1
+      ignore_errors: true
+
+    - name: Check ftp file copy put
+      ansible.builtin.assert:
+        that:
+          - test1.msg == 'File pushed OK'
+
+    - name: "File copy get by default scp"
+      juniper.device.file_copy:
+        local_dir: /tmp
+        remote_dir: /var/log
+        file: default_log.txt
+        action: get
+      register: test2
+
+    - name: Check scp file copy get
+      ansible.builtin.assert:
+        that:
+          - test2.msg == 'File pushed OK'
+
+    - name: "File copy put by default scp with checksum false option"
+      juniper.device.file_copy:
+        local_dir: /var/tmp
+        remote_dir: /var/log
+        file: checksum_log.txt
+        action: put
+        checksum: false
+      register: test1
+      ignore_errors: true
+
+    - name: Check ftp file copy put
+      ansible.builtin.assert:
+        that:
+          - test1.msg == 'File pushed OK'
+
+    - name: "File copy get by default scp with checksum false option"
+      juniper.device.file_copy:
+        local_dir: /tmp
+        remote_dir: /var/log
+        file: checksum_log.txt
+        action: get
+        checksum: false
+      register: test2
+
+    - name: Check default file copy get
+      ansible.builtin.assert:
+        that:
+          - test2.msg == 'File pushed OK'
+
+
+    - name: "File copy put by scp with transfer filename parameter"
+      juniper.device.file_copy:
+        protocol: scp
+        local_dir: /var/tmp
+        remote_dir: /var/log
+        file: default_log.txt
+        transfer_filename: transfer_log.txt
+        checksum: False
+        action: put
+      register: test1
+      ignore_errors: true
+
+    - name: Check scp file copy put
+      ansible.builtin.assert:
+        that:
+          - test1.msg == 'File pushed OK'
+
+    - name: "File copy get by scp with transfer filename parameter"
+      juniper.device.file_copy:
+        protocol: scp
+        local_dir: /tmp
+        remote_dir: /var/log
+        checksum: False
+        file: transfer_log.txt
+        transfer_filename: local_log.txt
+        action: get
+      register: test2
+
+    - name: Check scp file copy get
+      ansible.builtin.assert:
+        that:
+          - test2.msg == 'File pushed OK'
+
+    - name: "File copy put by ftp with transfer filename parameter"
+      juniper.device.file_copy:
+        protocol: ftp
+        local_dir: /var/tmp
+        remote_dir: /var/log
+        file: transfer_log.txt
+        transfer_filename: remote_log.txt
+        checksum: false
+        action: put
+      register: test1
+      ignore_errors: true
+
+    - name: Check ftp file copy put
+      ansible.builtin.assert:
+        that:
+          - test1.msg == 'File pushed OK'
+
+    - name: "File copy get by ftp with transfer filename parameter"
+      juniper.device.file_copy:
+        protocol: ftp
+        local_dir: /var/tmp
+        remote_dir: /var/log
+        checksum: False
+        file: remote_log.txt
+        transfer_filename: remote_log.txt
+        action: get
+      register: test2
+
+    - name: Check ftp file copy get
+      ansible.builtin.assert:
+        that:
+          - test2.msg == 'File pushed OK'
+


### PR DESCRIPTION
### Features Added

1. A new option, "protocol," has been added to allow users to choose the file transfer method: SCP or FTP. This is an optional parameter, with SCP set as the default.

2. A new option, "checksum," has been introduced to enable or disable validation using a boolean value of True or False. This is also an optional parameter, with True set as the default. When enabled, it validates the MD5 checksum algorithm before and after the file transfer. If set to False, no validation will be performed.

3. A new optional parameter, "transfer-file," allows you to specify the name of the file to be transferred. For example, if you want to copy a file named "XYZ" to a remote destination with a different name, "ABC," you can specify "ABC" in the transfer-file parameter. By default, the parameter will use the same name as the file being transferred.

### Sample Playbook

```
    - name: "File copy put by ftp with transfer filename parameter"
      juniper.device.file_copy:
        protocol: ftp
        local_dir: /var/tmp
        remote_dir: /var/log
        file: transfer_log.txt
        transfer_filename: remote_log.txt
        checksum: false
        action: put
      register: test1
      ignore_errors: true
```