### PR TITLE
Add functional tests for junipernetworks.junos modules

### DIFF
--- a/tests/junipernetworks.junos/ansible.cfg
+++ b/tests/junipernetworks.junos/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+hash_behaviour=merge
+inventory = inventory
+host_key_checking = False
+log_path = ./ansible.log
+
+[persistent_connection]
+command_timeout = 300

--- a/tests/junipernetworks.junos/inventory
+++ b/tests/junipernetworks.junos/inventory
@@ -1,0 +1,9 @@
+[junos]
+netconf_connection_testcases ansible_host=x.x.x.x
+
+[all:vars]
+ansible_python_interpreter=<python interpreter path>
+ansible_connection=netconf
+ansible_network_os=junipernetworks.junos.junos
+ansible_user=xxxx
+ansible_password=xxxx

--- a/tests/junipernetworks.junos/pb.juniper_junos_acl_interfaces.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_acl_interfaces.yml
@@ -1,0 +1,126 @@
+
+- name: Functional Test - junos_acl_interfaces module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  vars:
+    interface_name: "ge-1/0/0"
+    inbound_acl_name: "inbound_acl"
+    outbound_acl_name: "outbound_acl"
+
+  tasks:
+
+    - name: Setup - Ensure initial ACL config is absent (clean slate)
+      junos_acl_interfaces:
+        config:
+          - name: "{{ interface_name }}"
+            access_groups:
+              - afi: ipv4
+                acls:
+                  - name: "{{ inbound_acl_name }}"
+                    direction: in
+                  - name: "{{ outbound_acl_name }}"
+                    direction: out
+        state: deleted
+      register: cleanup_result
+
+    - name: Assert cleanup before test
+      assert:
+        that:
+          - cleanup_result.changed in [true, false]
+
+    - name: Pre-config - Create inbound and outbound ACL filters
+      junipernetworks.junos.junos_config:
+        lines:
+          - set firewall family inet filter {{ inbound_acl_name }} term 1 from source-address 10.0.0.0/8
+          - set firewall family inet filter {{ inbound_acl_name }} term 1 then accept
+          - set firewall family inet filter {{ outbound_acl_name }} term 1 from destination-address 192.168.0.0/16
+          - set firewall family inet filter {{ outbound_acl_name }} term 1 then accept
+        comment: "Test ACL filters for junos_acl_interfaces FT"
+
+    
+    - name: Test - Merge ACL config into interface
+      junos_acl_interfaces:
+        config:
+          - name: "{{ interface_name }}"
+            access_groups:
+              - afi: ipv4
+                acls:
+                  - name: "{{ inbound_acl_name }}"
+                    direction: in
+                  - name: "{{ outbound_acl_name }}"
+                    direction: out
+        state: merged
+      register: merge_result
+
+    - name: Assert merge operation
+      assert:
+        that:
+          - merge_result.changed == true
+          - merge_result.after is defined
+          - merge_result.commands | length > 0
+
+    
+    - name: Test - Replace ACL config with only input filter
+      junos_acl_interfaces:
+        config:
+          - name: "{{ interface_name }}"
+            access_groups:
+              - afi: ipv4
+                acls:
+                  - name: "{{ inbound_acl_name }}"
+                    direction: in
+        state: overridden
+      register: replace_result
+
+    - name: Assert override operation
+      assert:
+        that:
+          - replace_result.changed == true
+          - outbound_acl_name not in (replace_result.after | to_json)
+
+   
+    - name: Test - Override ACL config with both directions
+      junos_acl_interfaces:
+        config:
+          - name: "{{ interface_name }}"
+            access_groups:
+              - afi: ipv4
+                acls:
+                  - name: "{{ inbound_acl_name }}"
+                    direction: in
+                  - name: "{{ outbound_acl_name }}"
+                    direction: out
+        state: overridden
+      register: override_result
+
+    - name: Assert override operation
+      assert:
+        that:
+          - override_result.changed == true
+
+   
+    - name: Test - Delete ACL config
+      junos_acl_interfaces:
+        config:
+          - name: "{{ interface_name }}"
+            access_groups:
+              - afi: ipv4
+                acls:
+                  - name: "{{ inbound_acl_name }}"
+                    direction: in
+                  - name: "{{ outbound_acl_name }}"
+                    direction: out
+        state: deleted
+      register: delete_result
+
+    - name: Assert delete operation
+      assert:
+        that:
+          - delete_result.changed == true
+          - delete_result.after is defined
+
+    

--- a/tests/junipernetworks.junos/pb.juniper_junos_acls.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_acls.yml
@@ -1,0 +1,64 @@
+- name: Functional Test - junos_acls module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  vars:
+    acl_name: "allow_ssh_acl"
+    term_name: "ssh_rule"
+
+  tasks:
+
+    - name: Pre-clean - Delete test ACL if it exists
+      junos_acls:
+        config:
+          - afi: ipv4
+            acls:
+              - name: "{{ acl_name }}"
+        state: deleted
+      register: pre_cleanup
+
+    - name: Assert pre-clean success
+      assert:
+        that:
+          - pre_cleanup.changed in [true, false]
+
+   
+    - name: Apply ACL with state merged
+      junos_acls:
+        config:
+          - afi: ipv4
+            acls:
+              - name: "{{ acl_name }}"
+                aces:
+                  - name: "{{ term_name }}"
+                    source:
+                      port_protocol:
+                        eq: ssh
+                    protocol: tcp
+        state: merged
+      register: merge_result
+
+    - name: Assert merged config applied
+      assert:
+        that:
+          - merge_result.changed == true
+          - merge_result.after is defined
+          - merge_result.commands | length > 0
+
+    
+    - name: Post-clean - Remove ACL
+      junos_acls:
+        config:
+          - afi: ipv4
+            acls:
+              - name: "{{ acl_name }}"
+        state: deleted
+      register: post_cleanup
+
+    - name: Assert ACL was cleaned up
+      assert:
+        that:
+          - post_cleanup.changed == true

--- a/tests/junipernetworks.junos/pb.juniper_junos_banner.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_banner.yml
@@ -1,0 +1,76 @@
+- name: Functional Test - junos_banner module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  vars:
+    login_banner_text: |
+      this is my login banner
+      used for testing purposes
+
+  tasks:
+    - name: Pre-clean - Remove login banner if exists
+      junos_banner:
+        banner: login
+        state: absent
+      register: preclean_result
+
+    - name: Assert pre-clean successful
+      assert:
+        that:
+          - preclean_result.changed in [true, false]
+
+    - name: Apply login banner with state present
+      junos_banner:
+        banner: login
+        text: "{{ login_banner_text }}"
+        state: present
+      register: present_result
+
+    - name: Assert login banner applied
+      assert:
+        that:
+          - present_result.changed == true
+
+    - name: Deactivate the login banner
+      junipernetworks.junos.junos_banner:
+        banner: login
+        text: |
+          this is my login banner
+          used for testing purposes
+        state: present
+        active: false
+      register: deactivate_result 
+
+    - name: Assert login banner deactivated
+      assert:
+        that:
+          - deactivate_result.changed == true
+
+    - name: Reactivate the login banner
+      junos_banner:
+        banner: login
+        state: present
+        active: true
+        text: |
+          this is my login banner
+          used for testing purpose
+      register: reactivate_result
+
+    - name: Assert login banner reactivated
+      assert:
+        that:
+          - reactivate_result.changed == true
+
+    - name: Post-clean - Remove login banner
+      junos_banner:
+        banner: login
+        state: absent
+      register: postclean_result
+
+    - name: Assert login banner removed
+      assert:
+        that:
+          - postclean_result.changed == true

--- a/tests/junipernetworks.junos/pb.juniper_junos_command.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_command.yml
@@ -1,0 +1,68 @@
+
+
+- name: Functional Test - junos_command module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  tasks:
+    - name: Run show version
+      junipernetworks.junos.junos_command:
+        commands: show version
+      register: version_output
+
+    - name: Assert show version output is returned
+      assert:
+        that:
+          - version_output.stdout is defined
+          - "'Junos' in version_output.stdout[0]"
+
+    - name: Run show version with wait_for condition (positive match)
+      junipernetworks.junos.junos_command:
+        commands: show version
+        wait_for:
+          - result[0] contains Hostname
+      register: show_version_wait_positive
+
+    - name: Assert wait_for with positive match passed
+      assert:
+        that:
+          - show_version_wait_positive.stdout is defined
+          - show_version_wait_positive.failed_conditions is not defined
+
+    - name: Run multiple commands
+      junipernetworks.junos.junos_command:
+        commands:
+          - show version
+          - show interfaces terse
+      register: multi_output
+
+    - name: Assert multiple commands worked
+      assert:
+        that:
+          - multi_output.stdout | length == 2
+          - "'Interface' in multi_output.stdout[1]"
+
+    - name: Run show version with json output
+      junipernetworks.junos.junos_command:
+        commands: show version
+        display: json
+      register: json_output
+
+    - name: Assert json output is returned
+      assert:
+        that:
+          - json_output.stdout is defined
+          
+    - name: Run RPC get-software-information
+      junipernetworks.junos.junos_command:
+        rpcs: get-software-information
+      register: rpc_output
+
+    - name: Assert RPC output
+      assert:
+        that:
+          - rpc_output.stdout is defined
+          - rpc_output.stdout[0] is string

--- a/tests/junipernetworks.junos/pb.juniper_junos_config.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_config.yml
@@ -1,0 +1,67 @@
+- name: Functional Test - junos_config module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  tasks:
+
+    - name: Pre-clean - Remove existing test interface description
+      junos_config:
+        lines:
+          - delete interfaces ge-0/0/1 unit 0 description
+        comment: "Clean up test interface config"
+
+    - name: Assert pre-clean successful
+      assert:
+        that:
+          - "'delete interfaces' in apply_result.commands[0] or apply_result.changed in [true, false]"
+
+    - name: Apply test config - set interface description
+      junipernetworks.junos.junos_config:
+        lines:
+          - set interfaces ge-0/0/1 unit 0 description "FT Test interface"
+        comment: "Apply test config"
+      register: apply_result
+
+    - name: Assert interface config applied
+      assert:
+        that:
+          - apply_result.changed == true
+
+    - name: Confirm commit test with timer
+      junos_config:
+        lines:
+          - set system host-name ft-test-host
+        confirm: 3
+        comment: "Test commit confirmation"
+      # Intentionally allowing commit to rollback to test confirm  
+
+    - name: Rollback config to rollback 0
+      junos_config:
+        rollback: 0
+
+    - name: Backup config to custom path
+      junos_config:
+        lines:
+          - set system services ssh
+        backup: true
+        backup_options:
+          filename: ssh_backup.cfg
+          dir_path: ./backup
+      register: backup_result
+
+    - name: Assert backup created
+      assert:
+        that:
+          - backup_result.backup_path is defined
+          
+
+    - name: Post-clean - delete test configuration
+      junos_config:
+        lines:
+          - delete interfaces ge-0/0/1 unit 0 description
+          - delete system host-name
+          - delete system services ssh
+        comment: "Post-clean"

--- a/tests/junipernetworks.junos/pb.juniper_junos_facts.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_facts.yml
@@ -1,0 +1,44 @@
+- name: Functional Test - junos_facts module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  tasks:
+    - name: Collect default set of facts (min)
+      junipernetworks.junos.junos_facts:
+      register: default_facts
+
+    - name: Assert default facts gathered
+      assert:
+        that:
+          - default_facts.ansible_facts is defined
+          - default_facts.ansible_facts.ansible_net_model is defined
+          - default_facts.ansible_facts.ansible_net_hostname is defined
+
+    - name: Collect full facts including config and interfaces
+      junipernetworks.junos.junos_facts:
+        gather_subset:
+          - all
+      register: full_facts
+
+    - name: Assert full facts gathered
+      assert:
+        that:
+          - full_facts.ansible_facts.ansible_net_interfaces is defined
+          - full_facts.ansible_facts.ansible_net_config is defined
+
+    - name: Collect hardware and config with text format
+      junipernetworks.junos.junos_facts:
+        gather_subset:
+          - hardware
+          - config
+        config_format: text
+      register: hw_config_facts
+
+    - name: Assert hardware and config facts gathered
+      assert:
+        that:
+          - hw_config_facts.ansible_facts.ansible_net_config is defined
+          - "'system' in hw_config_facts.ansible_facts.ansible_net_config"

--- a/tests/junipernetworks.junos/pb.juniper_junos_hostname.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_hostname.yml
@@ -1,0 +1,57 @@
+- name: Functional Test - junos_hostname module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  vars:
+    test_hostname: "ft-host-20250424084647"
+
+  tasks:
+
+    - name: Pre-clean - Delete existing hostname
+      junipernetworks.junos.junos_hostname:
+        config: {}
+        state: deleted
+      register: delete_result
+
+    - name: Assert pre-clean success
+      assert:
+        that:
+          - delete_result.changed == true or delete_result.changed == false
+
+    - name: Apply hostname config with state merged
+      junipernetworks.junos.junos_hostname:
+        config:
+          hostname: "{{ test_hostname }}"
+        state: merged
+      register: merged_result
+
+    - name: Assert hostname was set
+      assert:
+        that:
+          - merged_result.changed == true
+          - merged_result.after.hostname == test_hostname
+
+    - name: Gather hostname config
+      junipernetworks.junos.junos_hostname:
+        state: gathered
+      register: gather_result
+
+    - name: Assert gathered hostname is correct
+      assert:
+        that:
+          - gather_result.changed == false
+          - gather_result.gathered.hostname == test_hostname
+
+    - name: Delete test hostname (post-clean)
+      junipernetworks.junos.junos_hostname:
+        config: {}
+        state: deleted
+      register: cleanup_result
+
+    - name: Assert hostname deleted
+      assert:
+        that:
+          - cleanup_result.changed == true

--- a/tests/junipernetworks.junos/pb.juniper_junos_interfaces.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_interfaces.yml
@@ -1,0 +1,64 @@
+- name: Functional Test - junos_interfaces module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  tasks:
+    - name: Pre-clean - Delete test configuration if present
+      junipernetworks.junos.junos_interfaces:
+        config:
+          - name: ge-0/0/1
+            units:
+              - name: 0
+        state: deleted
+      ignore_errors: true
+
+    - name: Apply test config with state merged
+      junipernetworks.junos.junos_interfaces:
+        config:
+          - name: ge-0/0/1
+            description: "FT updated interface"
+            enabled: true
+            mtu: 1800
+            units:
+              - name: 0
+                description: "FT logical unit"
+        state: merged
+      register: merge_result
+
+    - name: Gather current interface config
+      junipernetworks.junos.junos_interfaces:
+        state: gathered
+      register: gathered_result
+
+    - name: Assert merged interface config applied
+      assert:
+        that:
+          - merge_result.changed is defined
+          - gathered_result.gathered is defined
+          - gathered_result.gathered | selectattr("name", "equalto", "ge-0/0/1") | list | length > 0
+
+    - name: Render config offline (no connection to device)
+      junipernetworks.junos.junos_interfaces:
+        config:
+          - name: ge-0/0/1
+            description: Render test
+        state: rendered
+      register: render_result
+
+    - name: Assert rendered config returned
+      assert:
+        that:
+          - render_result.rendered is defined
+          - render_result.rendered | length > 0
+
+    - name: Post-clean - Delete test configuration
+      junipernetworks.junos.junos_interfaces:
+        config:
+          - name: ge-0/0/1
+            units:
+              - name: 0
+        state: deleted
+      ignore_errors: true

--- a/tests/junipernetworks.junos/pb.juniper_junos_l2_interfaces.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_l2_interfaces.yml
@@ -1,0 +1,84 @@
+- name: Functional Test - junos_l2_interfaces module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  tasks:
+    - name: Pre-define required VLANs
+      junipernetworks.junos.junos_vlans:
+        config:
+          - name: v101
+            vlan_id: 101
+          - name: vlan30
+            vlan_id: 30
+          - name: vlan50
+            vlan_id: 50
+        state: merged
+
+    - name: Pre-clean - Delete existing L2 config
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+          - name: ge-0/0/3
+          - name: ge-0/0/4
+        state: deleted
+      ignore_errors: true
+
+    - name: Apply L2 config - merge access and trunk modes
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+          - name: ge-0/0/3
+            access:
+              vlan: v101
+          - name: ge-0/0/4
+            trunk:
+              allowed_vlans: [ vlan30 ]
+              native_vlan: "50" 
+        state: merged
+      register: merge_result
+
+    - name: Assert L2 config merged
+      assert:
+        that:
+          - merge_result is defined
+          - merge_result.changed is defined
+          - merge_result.changed | bool == true
+
+    - name: Gather current L2 interface config
+      junipernetworks.junos.junos_l2_interfaces:
+        state: gathered
+      register: gathered_result
+
+    - name: Assert L2 config gathered
+      assert:
+        that:
+          - gathered_result.gathered | selectattr("name", "equalto", "ge-0/0/3") | list | length > 0
+          - gathered_result.gathered | selectattr("name", "equalto", "ge-0/0/4") | list | length > 0
+
+    - name: Render L2 config offline
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+          - name: ge-0/0/3
+            access:
+              vlan: v101
+          - name: ge-0/0/4
+            trunk:
+              allowed_vlans: [ vlan30 ]
+              native_vlan: 50
+        state: rendered
+      register: render_result
+
+    - name: Assert rendered L2 config
+      assert:
+        that:
+          - render_result.rendered is defined
+          - render_result.rendered | length > 0
+
+    - name: Post-clean - Delete L2 config
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+          - name: ge-0/0/3
+          - name: ge-0/0/4
+        state: deleted
+      ignore_errors: true

--- a/tests/junipernetworks.junos/pb.juniper_junos_l3_interfaces.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_l3_interfaces.yml
@@ -1,0 +1,73 @@
+- name: Functional Test - junos_l3_interfaces module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  tasks:
+
+    - name: Pre-clean - Delete L3 logical interfaces if present
+      junos_l3_interfaces:
+        config:
+          - name: ge-0/0/1
+          - name: ge-0/0/2
+        state: deleted
+      ignore_errors: true
+
+    - name: Apply L3 configuration (merge)
+      junos_l3_interfaces:
+        config:
+          - name: ge-0/0/1
+            ipv4:
+              - address: 192.168.1.10/24
+            ipv6:
+              - address: 2001:db8::1/64
+          - name: ge-0/0/2
+            ipv4:
+              - address: dhcp
+        state: merged
+      register: merge_result
+
+    - name: Assert L3 config applied
+      assert:
+        that:
+          - merge_result.changed is defined
+          - merge_result.after | selectattr("name", "equalto", "ge-0/0/1") | list | length > 0
+          - merge_result.after | selectattr("name", "equalto", "ge-0/0/2") | list | length > 0
+
+    - name: Gather L3 interfaces
+      junos_l3_interfaces:
+        state: gathered
+      register: gathered_result
+
+    - name: Assert L3 interfaces gathered
+      assert:
+        that:
+          - gathered_result.gathered | selectattr("name", "equalto", "ge-0/0/1") | list | length > 0
+          - gathered_result.gathered | selectattr("name", "equalto", "ge-0/0/2") | list | length > 0
+
+    - name: Render L3 config (offline)
+      junos_l3_interfaces:
+        config:
+          - name: ge-0/0/1
+            ipv4:
+              - address: 192.168.1.10/24
+            ipv6:
+              - address: 2001:db8::1/64
+        state: rendered
+      register: render_result
+
+    - name: Assert rendered config is present
+      assert:
+        that:
+          - render_result.rendered is defined
+          - render_result.rendered | length > 0
+
+    - name: Post-clean - Delete test L3 configuration
+      junos_l3_interfaces:
+        config:
+          - name: ge-0/0/1
+          - name: ge-0/0/2
+        state: deleted
+      ignore_errors: true

--- a/tests/junipernetworks.junos/pb.juniper_junos_lacp.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_lacp.yml
@@ -1,0 +1,56 @@
+- name: Functional Test - junos_lacp module
+  hosts: junos
+  gather_facts: false
+  connection: netconf
+  collections:
+    - junipernetworks.junos
+
+  tasks:
+
+    - name: Pre-clean - Delete existing global LACP config
+      junos_lacp:
+        state: deleted
+      ignore_errors: true
+
+    - name: Merge global LACP attributes
+      junos_lacp:
+        config:
+          system_priority: 63
+          # link_protection: revertive
+        state: merged
+      register: merge_result
+
+    - name: Assert LACP config merged
+      assert:
+        that:
+          - merge_result.changed is defined
+
+    - name: Gather global LACP config
+      junos_lacp:
+        state: gathered
+      register: gather_result
+
+    - name: Assert gathered global LACP config
+      assert:
+        that:
+          - gather_result.gathered.system_priority == 63
+          - "'link_protection' not in gather_result.gathered or gather_result.gathered.link_protection == 'revertive'"
+
+    - name: Render LACP config (offline)
+      junos_lacp:
+        config:
+          system_priority: 63
+          link_protection: revertive
+        state: rendered
+      register: render_result
+
+    - name: Assert rendered config is returned
+      assert:
+        that:
+          - render_result.rendered is defined
+          - render_result.rendered | length > 0
+
+    - name: Post-clean - Delete global LACP config
+      junos_lacp:
+        state: deleted
+      ignore_errors: true

--- a/tests/junipernetworks.junos/pb.juniper_junos_lacp_interfaces.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_lacp_interfaces.yml
@@ -1,0 +1,82 @@
+---
+- name: Functional Test - junos_lacp_interfaces module
+  hosts: netconf_connection_testcases
+  gather_facts: false
+  connection: ansible.netcommon.netconf
+
+  tasks:
+
+    - name: Pre-clean - Delete LACP interfaces attributes of given interfaces
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+          - name: ae0
+          - name: ge-0/0/2
+          - name: ge-0/0/3
+        state: deleted
+
+    - name: Merge provided configuration with device configuration
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+          - name: ae0
+            period: fast
+            sync_reset: enable
+            system:
+              priority: 100
+              mac:
+                address: 00:00:00:00:00:02
+          - name: ge-0/0/3
+            port_priority: 100
+            force_up: true
+        state: merged
+
+    - name: Replace device LACP interfaces configuration with provided configuration
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+          - name: ae0
+            period: slow
+        state: replaced
+
+    - name: Overrides all device LACP interfaces configuration with provided configuration
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+          - name: ae0
+            system:
+              priority: 300
+              mac:
+                address: 00:00:00:00:00:03
+          - name: ge-0/0/2
+            port_priority: 200
+            force_up: false
+        state: overridden
+
+    - name: Gather junos lacp interfaces facts
+      junipernetworks.junos.junos_lacp_interfaces:
+        state: gathered
+      register: gather_result
+
+    - name: Extract interface names from gathered result
+      set_fact:
+        gathered_names: "{{ gather_result.gathered | map(attribute='name') | list }}"  
+
+    - name: Assert gathered includes ae0 and ge-0/0/2
+      ansible.builtin.assert:
+        that:
+          - "'ae0' in gathered_names"
+          - "'ge-0/0/2' in gathered_names"
+        fail_msg: "Expected interfaces ae0 and ge-0/0/2 not found in gathered result"
+        success_msg: "Successfully found ae0 and ge-0/0/2 in gathered result"
+
+    - name: Render platform specific xml from task input using rendered state
+      junipernetworks.junos.junos_lacp_interfaces:
+        config:
+          - name: ae0
+            period: fast
+            sync_reset: enable
+            system:
+              priority: 100
+              mac:
+                address: 00:00:00:00:00:02
+          - name: ge-0/0/3
+            port_priority: 100
+            force_up: true
+        state: rendered

--- a/tests/junipernetworks.junos/pb.juniper_junos_lldp_global.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_lldp_global.yml
@@ -1,0 +1,54 @@
+- name: Functional Test - junos_lldp_global module
+  hosts: netconf_connection_testcases
+  connection: ansible.netcommon.netconf
+  gather_facts: false
+  tasks:
+
+    - name: Merge LLDP global configuration
+      junipernetworks.junos.junos_lldp_global:
+        config:
+          interval: 10000
+          address: 10.1.1.1
+          transmit_delay: 400
+          hold_multiplier: 10
+        state: merged
+
+    - name: Replace LLDP global configuration
+      junipernetworks.junos.junos_lldp_global:
+        config:
+          address: 20.2.2.2
+          hold_multiplier: 5
+          enabled: false
+        state: replaced
+
+    - name: Gather LLDP global configuration
+      junipernetworks.junos.junos_lldp_global:
+        state: gathered
+      register: gather_result
+
+    - name: Assert LLDP address is correctly configured
+      ansible.builtin.assert:
+        that:
+          - gather_result.gathered.address == "20.2.2.2"
+          - gather_result.gathered.hold_multiplier == 5
+          - gather_result.gathered.enabled == false
+        success_msg: "LLDP global settings gathered correctly"
+        fail_msg: "LLDP global settings did not match expected values"
+
+    - name: Render LLDP global configuration to XML
+      junipernetworks.junos.junos_lldp_global:
+        config:
+          interval: 10000
+          address: 10.1.1.1
+          transmit_delay: 400
+          hold_multiplier: 10
+        state: rendered
+      register: render_result
+
+    - name: Debug rendered LLDP XML
+      ansible.builtin.debug:
+        var: render_result.rendered
+
+    - name: Delete LLDP global configuration
+      junipernetworks.junos.junos_lldp_global:
+        state: deleted

--- a/tests/junipernetworks.junos/pb.juniper_junos_lldp_interfaces.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_lldp_interfaces.yml
@@ -1,0 +1,63 @@
+- name: Functional Test - junos_lldp_interfaces module
+  hosts: netconf_connection_testcases
+  connection: ansible.netcommon.netconf
+  gather_facts: false
+  tasks:
+
+    - name: Pre-clean LLDP interface config
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+          - name: ge-0/0/1
+          - name: ge-0/0/2
+          - name: ge-0/0/3
+        state: deleted
+      ignore_errors: true
+
+    - name: Merge LLDP interface configuration
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+          - name: ge-0/0/1
+          - name: ge-0/0/2
+            enabled: false
+        state: merged
+
+    - name: Replace LLDP interface configuration
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+          - name: ge-0/0/2
+            enabled: true
+          - name: ge-0/0/3
+            enabled: false
+        state: replaced
+
+    - name: Override LLDP interface configuration
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+          - name: ge-0/0/3
+            enabled: false
+        state: overridden
+
+    - name: Gather current LLDP interface configuration
+      junipernetworks.junos.junos_lldp_interfaces:
+        state: gathered
+      register: lldp_interface_gather
+
+    - name: Assert ge-0/0/3 is in gathered LLDP interfaces and disabled
+      ansible.builtin.assert:
+        that:
+          - lldp_interface_gather.gathered | selectattr("name", "equalto", "ge-0/0/3") | selectattr("enabled", "equalto", false) | list | length > 0
+        fail_msg: "ge-0/0/3 with enabled: false not found in gathered result"
+        success_msg: "ge-0/0/3 is correctly disabled in LLDP interfaces"
+
+    - name: Render LLDP interface configuration for offline validation
+      junipernetworks.junos.junos_lldp_interfaces:
+        config:
+          - name: ge-0/0/1
+          - name: ge-0/0/2
+            enabled: false
+        state: rendered
+      register: rendered_lldp
+
+    - name: Debug rendered XML
+      ansible.builtin.debug:
+        var: rendered_lldp.rendered

--- a/tests/junipernetworks.junos/pb.juniper_junos_netconf.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_netconf.yml
@@ -1,0 +1,29 @@
+# NOTE: This module requires 'network_cli' connection type.
+# Run this playbook using:
+# ansible-playbook -i inventory pb.juniper_junos_netconf.yml -e ansible_connection=network_cli
+
+- name: Functional Test - junos_netconf module
+  hosts: netconf_connection_testcases
+  gather_facts: false
+  connection: network_cli  
+
+  tasks:
+
+    - name: Enable NETCONF service on port 830
+      junipernetworks.junos.junos_netconf:
+        netconf_port: 830
+        state: present
+      register: enable_result
+
+    - name: Debug NETCONF enable command
+      ansible.builtin.debug:
+        var: enable_result.commands
+
+    - name: Disable NETCONF service
+      junipernetworks.junos.junos_netconf:
+        state: absent
+      register: disable_result
+
+    - name: Debug NETCONF disable command
+      ansible.builtin.debug:
+        var: disable_result.commands

--- a/tests/junipernetworks.junos/pb.juniper_junos_user.yml
+++ b/tests/junipernetworks.junos/pb.juniper_junos_user.yml
@@ -1,0 +1,46 @@
+---
+- name: Functional Test - junos_user module
+  hosts: netconf_connection_testcases
+  gather_facts: false
+  connection: ansible.netcommon.netconf
+
+  tasks:
+    - name: Ensure test user is absent before test
+      junipernetworks.junos.junos_user:
+        name: ansible_test_user
+        state: absent
+      ignore_errors: true
+
+    - name: Create a new user account with optional SSH key
+      junipernetworks.junos.junos_user:
+        name: ansible_test_user
+        role: super-user
+        sshkey: "{{ user_ssh_key | default(omit) }}"
+        full_name: "Ansible Test User"
+        state: present
+      # Note: Provide SSH key using:
+      # ansible-playbook pb.juniper_junos_user.yml -e "user_ssh_key={{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+
+    - name: Set user password (SHA-512 hashed)
+      junipernetworks.junos.junos_user:
+        name: ansible_test_user
+        role: super-user
+        encrypted_password: "{{ 'testpass123' | password_hash('sha512') }}"
+        state: present
+
+    - name: Create a list of additional users
+      junipernetworks.junos.junos_user:
+        aggregate:
+          - { name: test_user1, full_name: "Operator User", role: operator, state: present }
+          - { name: test_user2, full_name: "ReadOnly User", role: read-only, state: present }
+
+    - name: Delete additional users
+      junipernetworks.junos.junos_user:
+        aggregate:
+          - { name: test_user1, full_name: "Operator User", role: operator, state: absent }
+          - { name: test_user2, full_name: "ReadOnly User", role: read-only, state: absent }
+
+    - name: Remove the test user account
+      junipernetworks.junos.junos_user:
+        name: ansible_test_user
+        state: absent


### PR DESCRIPTION
This pull request adds a new directory under `tests/junipernetworks.junos/` containing 16 functional test playbooks for validating modules in the `junipernetworks.junos` Ansible collection.