### PR TITLE
Fix Ansible automation hub support review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ For each failed test, a log will be printed after the RECAP of the playbook as s
     Value of 'peer-state' not 'is-equal' at '//bgp-information/bgp-peer' with {"peer-as": "65200", "peer-state": "Active", "peer-address": "100.0.0.21"}
 
 Callback plugins are not activated by default. They must be manually added to the Ansible
-configuration file under the `[defaults]` section using the variable `callback_whitelist`. Specifically, these lines
+configuration file under the `[defaults]` section using the variable `callbacks_enabled = juniper.device.jsnapy`. Specifically, these lines
 should be added to the Ansible configuration file in order to allow the jsnapy callback plugin:
 
     [defaults]
-    callback_whitelist = jsnapy
+    callbacks_enabled = juniper.device.jsnapy 
 
 [Official Juniper documentation](http://www.juniper.net/techpubs/en_US/release-independent/junos-ansible/information-products/pathway-pages/index.html) (detailed information, including examples)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Juniper Ansible collection for Junos
 
-## About
+## Description
 
 Juniper Networks supports Ansible for managing devices running the Junos operating system (Junos OS and Junos Evolved).
 This collection is hosted on the Ansible Galaxy website under the collection
@@ -32,10 +32,6 @@ This `juniper.device` collection includes the following modules:
 - **system** — Initiate operational actions on the Junos system.
 - **table** — Retrieve data from a Junos device using a PyEZ table/view.
 
-### PyEZ Version Requirement
-
-For ansible collection `juniper.device` we will need to install [junos-eznc](https://github.com/Juniper/py-junos-eznc) version 2.6.0 or higher.
-
 ### Overview of Plugins
 
 In addition to the modules listed above, a callback_plugin `jsnapy` is available for the module [jsnapy](https://github.com/Juniper/jsnapy).
@@ -63,18 +59,56 @@ should be added to the Ansible configuration file in order to allow the jsnapy c
     [defaults]
     callback_whitelist = jsnapy
 
-## DOCUMENTATION
-
 [Official Juniper documentation](http://www.juniper.net/techpubs/en_US/release-independent/junos-ansible/information-products/pathway-pages/index.html) (detailed information, including examples)
 
 [Ansible style documentation](https://ansible-juniper-collection.readthedocs.io)
 
-## INSTALLATION
+## Requirements
+
+This modules requires the following to be installed on the Ansible control machine:
+
+- Python >= 3.8
+- [Ansible](https://pypi.org/project/ansible/) 2.9 or later
+- Junos [py-junos-eznc](https://github.com/Juniper/py-junos-eznc) 2.6.0 or later
+- [jxmlease](https://github.com/Juniper/jxmlease) 1.0.1 or later
+- [xmltodict](https://pypi.org/project/xmltodict/) 0.13.0 or later
+- [jsnapy](https://github.com/Juniper/jsnapy) 1.3.7 or later
+
+## Installation
 
 You must have the [DEPENDENCIES](https://github.com/Juniper/ansible-junos-stdlib/blob/master/README.md#dependencies) installed on your system.
 Check requirements.txt for the dependencies.
 
-### NOTICES
+Before using this collection, you need to install it with the Ansible Galaxy command-line tool:
+
+```bash
+ansible-galaxy collection install juniper.device
+```
+
+You can also include it in a requirements.yml file and install it with ansible-galaxy collection install -r requirements.yml, using the format:
+
+
+```yaml
+collections:
+  - name: juniper.device
+```
+
+To upgrade the collection to the latest available version, run the following command:
+
+```bash
+ansible-galaxy collection install juniper.devie --upgrade
+```
+
+You can also install a specific version of the collection. Use the following syntax to install version 1.0.0:
+
+```bash
+ansible-galaxy collection install juniper.device:==1.0.0
+```
+
+See [using Ansible collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html) for more details.
+
+
+### Notices
 
 ### MacOS Mojave and newer
 
@@ -84,36 +118,7 @@ In MacOS Mojave and newer (>=10.14), ssh keys created with the system `ssh-keyge
 - Check existing keys: `head -n1 ~/.ssh/some_private_key` RSA keys will be `-----BEGIN RSA PRIVATE KEY-----` and OPENSSH keys will be `-----BEGIN OPENSSH PRIVATE KEY-----`
 - Convert an OPENSSH key to an RSA key: `ssh-keygen -p -m PEM -f ~/.ssh/some_key`
 
-### Ansible Galaxy collection
-
-You can use the ansible-galaxy install command to install the latest
-version of the `juniper.device` collection.
-
-```bash
-sudo ansible-galaxy collection install juniper.device
-```
-
-You can also use the ansible-galaxy install command to install the latest development version of the junos collections directly from GitHub.
-
-```bash
-sudo ansible-galaxy collection install git+https://github.com/Juniper/ansible-junos-stdlib.git#/ansible_collections/juniper/device
-```
-
-For more information visit - https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#specifying-the-location-to-search-for-collections
-
-
-### Git clone
-
-For testing you can `git clone` [this repo](https://github.com/Juniper/ansible-junos-stdlib.git) and run the `env-setup` script in the repo directory:
-
-  user@ansible-junos-stdlib> source env-setup
-
-This will set your `$ANSIBLE_LIBRARY` variable to the repo location and the installed Ansible library path.  For example:
-
-  $ echo $ANSIBLE_LIBRARY
-  /home/jeremy/Ansible/ansible-junos-stdlib/library:/usr/share/ansible
-
-## Example Playbook
+## Use Cases
 
 This example outlines how to use Ansible to install or upgrade the software image on a device running Junos OS.
 
@@ -155,33 +160,19 @@ This example outlines how to use Ansible to install or upgrade the software imag
       when: not sw.check_mode
 ```
 
-## DEPENDENCIES
+## Testing
 
-This modules requires the following to be installed on the Ansible control machine:
-
-- Python >= 3.8
-- [Ansible](https://pypi.org/project/ansible/) 2.9 or later
-- Junos [py-junos-eznc](https://github.com/Juniper/py-junos-eznc) 2.6.0 or later
-- [jxmlease](https://github.com/Juniper/jxmlease) 1.0.1 or later
-- [xmltodict](https://pypi.org/project/xmltodict/) 0.13.0 or later
-- [jsnapy](https://github.com/Juniper/jsnapy) 1.3.7 or later
-
-## LICENSE
-
-Apache 2.0
+[Please refer Funcational Tests](https://github.com/Juniper/ansible-junos-stdlib/tree/master/tests#readme)
 
 ## SUPPORT
 
-As a Red Hat Ansible [Certified Content](https://catalog.redhat.com/en/search?searchType=Software), this collection is entitled to [support](https://access.redhat.com/support/) through [Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible) (AAP) using the **Create issue** button on the top right corner.
+As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
 
-If a support case cannot be opened with Red Hat and the collection has been obtained either from [Galaxy](https://galaxy.ansible.com/ui/) or [GitHub](https://github.com/Juniper/ansible-junos-stdlib), there is community support available, you may:
+## Release Notes and Roadmap
 
-- Open a [GitHub issue](https://github.com/Juniper/ansible-junos-stdlib/issues).
-- Post a question on our [Google Group](https://groups.google.com/forum/#!forum/junos-python-ez)
-- Email [jnpr-community-netdev@juniper.net](jnpr-community-netdev@juniper.net)
-- Open a [JTAC Case](https://www.juniper.net/casemanager/#/create)
+[Release Notes](https://github.com/Juniper/ansible-junos-stdlib/blob/master/ansible_collections/juniper/device/CHANGELOG.rst)
 
-## CONTRIBUTORS
+## Contributing
 
 Juniper Networks is actively contributing to and maintaining this repo. Please contact
 [jnpr-community-netdev@juniper.net](jnpr-community-netdev@juniper.net) for any queries.
@@ -192,3 +183,12 @@ Juniper Networks is actively contributing to and maintaining this repo. Please c
 *Former Contributors:*
 
 [Stacy W Smith](https://github.com/stacywsmith), [Jeremy Schulman](https://github.com/jeremyschulman), [Rick Sherman](https://github.com/shermdog), [Damien Garros](https://github.com/dgarros), [David Gethings](https://github.com/dgjnpr), [Nitin Kumar](https://github.com/vnitinv), [Rahul Kumar](https://github.com/rahkumar651991)
+
+
+## Support
+
+As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
+
+## License Information
+
+Apache 2.0

--- a/ansible_collections/juniper/device/README.md
+++ b/ansible_collections/juniper/device/README.md
@@ -51,11 +51,11 @@ For each failed test, a log will be printed after the RECAP of the playbook as s
     Value of 'peer-state' not 'is-equal' at '//bgp-information/bgp-peer' with {"peer-as": "65200", "peer-state": "Active", "peer-address": "100.0.0.21"}
 
 Callback plugins are not activated by default. They must be manually added to the Ansible
-configuration file under the `[defaults]` section using the variable `callback_whitelist`. Specifically, these lines
+configuration file under the `[defaults]` section using the variable `callbacks_enabled = juniper.device.jsnapy`. Specifically, these lines
 should be added to the Ansible configuration file in order to allow the jsnapy callback plugin:
 
     [defaults]
-    callback_whitelist = jsnapy
+    callbacks_enabled = juniper.device.jsnapy 
 
 [Official Juniper documentation](http://www.juniper.net/techpubs/en_US/release-independent/junos-ansible/information-products/pathway-pages/index.html) (detailed information, including examples)
 

--- a/ansible_collections/juniper/device/README.md
+++ b/ansible_collections/juniper/device/README.md
@@ -1,5 +1,3 @@
-[![Documentation Status](https://readthedocs.org/projects/junos-ansible-modules/badge/?version=stable)](https://junos-ansible-modules.readthedocs.io/en/2.3.0/)
-
 # Juniper Ansible collection for Junos
 
 ## Description
@@ -11,14 +9,12 @@ This collection is hosted on the Ansible Galaxy website under the collection
 The `juniper.device` collection includes a set of Ansible modules that perform specific operational and configuration tasks on devices running Junos OS.
 These tasks include: installing and upgrading Junos OS, provisioning new Junos devices in the network, loading configuration changes,
 retrieving information, and resetting, rebooting, or shutting down managed devices.  Please refer to the
-[INSTALLATION](#installation) section for instructions on installing this collection.
+[INSTALLATION](https://github.com/Juniper/ansible-junos-stdlib/blob/master/README.md#installation) section for instructions on installing this collection.
 
-Since Ansible version >= 2.1, Ansible also natively includes
-[core modules for Junos](https://docs.ansible.com/ansible/latest/collections/junipernetworks/junos/index.html#plugins-in-junipernetworks-junos). The Junos modules included
-in Ansible core have names which begin with the prefix `junos_`. The Junos modules included in this `Juniper.device`
-collection have names starting with module types. These two sets of Junos modules can coexist on the same
-Ansible control machine, and an Ansible playbook may invoke a module from either (or both) sets. Juniper Networks recommends
-using the modules in `juniper.device` collection when writing new playbooks that manage Junos devices.
+This collection is compatible with [junipernetworks.junos](https://github.com/ansible-collections/junipernetworks.junos) certified collection.
+
+## Overview of Modules
+
 This `juniper.device` collection includes the following modules:
 
 - **command** — Execute one or more CLI commands on a Junos device.
@@ -33,6 +29,8 @@ This `juniper.device` collection includes the following modules:
 - **srx_cluster** — Add or remove SRX chassis cluster configuration.
 - **system** — Initiate operational actions on the Junos system.
 - **table** — Retrieve data from a Junos device using a PyEZ table/view.
+
+### Overview of Plugins
 
 In addition to the modules listed above, a callback_plugin `jsnapy` is available for the module [jsnapy](https://github.com/Juniper/jsnapy).
 
@@ -59,24 +57,29 @@ should be added to the Ansible configuration file in order to allow the jsnapy c
     [defaults]
     callback_whitelist = jsnapy
 
+[Official Juniper documentation](http://www.juniper.net/techpubs/en_US/release-independent/junos-ansible/information-products/pathway-pages/index.html) (detailed information, including examples)
+
+[Ansible style documentation](https://ansible-juniper-collection.readthedocs.io)
+
 ## Requirements
 
 This modules requires the following to be installed on the Ansible control machine:
 
-- Python >= 3.10
-- [Ansible](http://www.ansible.com) 2.17 or later
-- Junos [py-junos-eznc](https://github.com/Juniper/py-junos-eznc) 2.7.3 or later
+- Python >= 3.8
+- [Ansible](https://pypi.org/project/ansible/) 2.9 or later
+- Junos [py-junos-eznc](https://github.com/Juniper/py-junos-eznc) 2.6.0 or later
 - [jxmlease](https://github.com/Juniper/jxmlease) 1.0.1 or later
 - [xmltodict](https://pypi.org/project/xmltodict/) 0.13.0 or later
 - [jsnapy](https://github.com/Juniper/jsnapy) 1.3.7 or later
-- [packaging](https://github.com/pypa/packaging) 25.0 or later
-
 
 ## Installation
 
+You must have the [DEPENDENCIES](https://github.com/Juniper/ansible-junos-stdlib/blob/master/README.md#dependencies) installed on your system.
+Check requirements.txt for the dependencies.
+
 Before using this collection, you need to install it with the Ansible Galaxy command-line tool:
 
-```
+```bash
 ansible-galaxy collection install juniper.device
 ```
 
@@ -88,26 +91,30 @@ collections:
   - name: juniper.device
 ```
 
-Note that if you install any collections from Ansible Galaxy, they will not be upgraded automatically when you upgrade the Ansible package.
 To upgrade the collection to the latest available version, run the following command:
 
-```
-ansible-galaxy collection install juniper.device --upgrade
+```bash
+ansible-galaxy collection install juniper.devie --upgrade
 ```
 
-You can also install a specific version of the collection, for example, if you need to downgrade when something is broken in the latest version (please report an issue in this repository). Use the following syntax to install version 1.0.0:
+You can also install a specific version of the collection. Use the following syntax to install version 1.0.0:
 
+```bash
+ansible-galaxy collection install juniper.device:==1.0.0
 ```
-ansible-galaxy collection install juniper.device==1.0.0
-```
+
+See [using Ansible collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html) for more details.
+
+
+### Notices
+
+### MacOS Mojave and newer
 
 In MacOS Mojave and newer (>=10.14), ssh keys created with the system `ssh-keygen` are created using the newer 'OPENSSH' key format, even when specifying `-t rsa` during creation. This directly affects the usage of ssh keys, particularly when using the `ssh_private_key_file`. To create/convert/check keys, follow these steps:
 
 - Create a new RSA key: `ssh-keygen -m PEM -t rsa -b 4096`
 - Check existing keys: `head -n1 ~/.ssh/some_private_key` RSA keys will be `-----BEGIN RSA PRIVATE KEY-----` and OPENSSH keys will be `-----BEGIN OPENSSH PRIVATE KEY-----`
 - Convert an OPENSSH key to an RSA key: `ssh-keygen -p -m PEM -f ~/.ssh/some_key`
-
-See [using Ansible collections](https://docs.ansible.com/ansible/devel/user_guide/collections_using.html) for more details.
 
 ## Use Cases
 
@@ -153,47 +160,17 @@ This example outlines how to use Ansible to install or upgrade the software imag
 
 ## Testing
 
+[Please refer Funcational Tests](https://github.com/Juniper/ansible-junos-stdlib/tree/master/tests#readme)
 
-[Functional Tests for Juniper Ansible collection for Junos][https://github.com/Juniper/ansible-junos-stdlib/blob/master/tests/README.md]
+## SUPPORT
 
-## Contributing (Optional)
-
-We welcome community contributions to this collection. If you find problems, please open an issue or create a PR against the [GitHub issue](https://github.com/Juniper/ansible-junos-stdlib/issues)
-
-You can also join us on:
-
-- Email [jnpr-community-netdev@juniper.net](jnpr-community-netdev@juniper.net)
-
-See the [Ansible Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) for details on contributing to Ansible.
-
-This collection follows the Ansible project's
-[Code of Conduct](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html).
-Please read and familiarize yourself with this document.
-
-## Support
-
-Support for this `juniper.device` collection is provided by the community and Juniper Networks. If you have an
-issue with a module in the `juniper.device` collection, you may:
-
-- Open a [GitHub issue](https://github.com/Juniper/ansible-junos-stdlib/issues).
-- Email [jnpr-community-netdev@juniper.net](jnpr-community-netdev@juniper.net)
-- Open a [JTAC Case](https://www.juniper.net/casemanager/#/create)
-
-Support for the Junos modules included in Ansible core is provided by Ansible. If you have an issue with an Ansible
-core module you should open a [Github issue against the Ansible project](https://github.com/ansible/ansible/issues).
+As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
 
 ## Release Notes and Roadmap
 
-Release notes are available [here](https://github.com/Juniper/ansible-junos-stdlib/releases).
+[Release Notes](https://github.com/Juniper/ansible-junos-stdlib/blob/master/ansible_collections/juniper/device/CHANGELOG.rst)
 
-
-## Related Information
-
-[Official Juniper documentation](http://www.juniper.net/techpubs/en_US/release-independent/junos-ansible/information-products/pathway-pages/index.html) (detailed information, including examples)
-
-[Ansible style documentation](https://ansible-juniper-collection.readthedocs.io)
-
-## Contributors
+## Contributing
 
 Juniper Networks is actively contributing to and maintaining this repo. Please contact
 [jnpr-community-netdev@juniper.net](jnpr-community-netdev@juniper.net) for any queries.
@@ -204,6 +181,11 @@ Juniper Networks is actively contributing to and maintaining this repo. Please c
 *Former Contributors:*
 
 [Stacy W Smith](https://github.com/stacywsmith), [Jeremy Schulman](https://github.com/jeremyschulman), [Rick Sherman](https://github.com/shermdog), [Damien Garros](https://github.com/dgarros), [David Gethings](https://github.com/dgjnpr), [Nitin Kumar](https://github.com/vnitinv), [Rahul Kumar](https://github.com/rahkumar651991)
+
+
+## Support
+
+As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
 
 ## License Information
 

--- a/ansible_collections/juniper/device/plugins/callback/jsnapy.py
+++ b/ansible_collections/juniper/device/plugins/callback/jsnapy.py
@@ -36,6 +36,56 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+
+DOCUMENTATION = """
+---
+name: jsnapy
+type: callback
+author: Juniper Networks, Roslan Zaki, Damien Garros, Stacy Smith (@stacywsmith)
+short_description: Formats and prints JSNAPy test results for Junos devices
+description: |
+  This callback plugin provides extra logging and human-readable output for JSNAPy test results executed via Ansible.
+  It collects and displays pass/fail details for each JSNAPy test when the action is snapcheck or check.
+  The jsnapy callback plugin is disabled by default. To enable the jsnapy callback plugin, add the
+  callbacks_enabled = juniper.device.jsnapy statement to the Ansible configuration file.
+  Example:
+    [defaults]
+    callbacks_enabled = juniper.device.jsnapy
+  For more information on JSNAPy, see https://github.com/Juniper/jsnapy and
+  https://www.juniper.net/documentation/en_US/day-one-books/DO_JSNAPy.zip.
+options: {}
+"""
+
+
+EXAMPLES = """
+- name: Run JSNAPy snapcheck
+  hosts: junos-all
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Run JSNAPy snapcheck
+      juniper.device.jsnapy:
+        action: "snapcheck"
+        test_files: "tests/test_junos_interface.yaml"
+      register: test_result
+    - name: Print JSNAPy test results
+      ansible.builtin.debug:
+        var: test_result
+"""
+
+RETURN = """
+test_results:
+  description:
+    - Detailed results of each JSNAPy test executed, including pass/fail counts and test details.
+  returned: always
+  type: dict
+msg:
+  description:
+    - Human-readable summary of JSNAPy validation, printed to the console by the callback plugin.
+  returned: always
+  type: str
+"""
+
 import json
 import pprint
 


### PR DESCRIPTION
Fix for Ansible Automation hub upload review comments
```
Item #1 Error in import logs:
callback juniper.device.jsnapy missing documentation (or could not parse documentation): No documentation available for juniper.device.jsnapy (/tmp/tmpsxl64wuk/ansible_collections/juniper/device/plugins/callback/jsnapy.py)

Item #2 Support statement in the README

Item #3 Address requested changes to README from version 1.0.8. 
```

```
(ansiahrev1) root@masterhost:~/ansible_autohub_review1/ansible-junos-stdlib/ansible_collections/juniper/device# python -m galaxy_importer.main juniper-device-1.0.9.tar.gz 
Importing with galaxy-importer 0.4.33
Getting doc strings via ansible-doc
Finding content inside collection
Loading action command
Loading action config
Loading action extract_data
Loading action facts
Loading action file_copy
Loading action jsnapy
Loading action juniper_junos_common_action
Loading action ping
Loading action pmtud
Loading action rpc
Loading action software
Loading action srx_cluster
Loading action system
Loading action table
Loading callback jsnapy
Loading connection pyez
Loading doc_fragments juniper_junos_doc
Loading module command
Loading module config
Loading module facts
Loading module file_copy
Loading module jsnapy
Loading module ping
Loading module pmtud
Loading module rpc
Loading module software
Loading module srx_cluster
Loading module system
Loading module table
Loading module_utils configuration
Loading module_utils juniper_junos_common
Linting collection via ansible-lint 25.8.2...
...ansible-lint run complete
WARNING: Ignore files skip ansible-test sanity tests, found ignore-2.16.txt with 17 statement(s)
WARNING: Ignore files skip ansible-test sanity tests, found ignore-2.17.txt with 17 statement(s)
WARNING: Ignore files skip ansible-test sanity tests, found ignore-2.18.txt with 17 statement(s)
WARNING: Ignore files skip ansible-test sanity tests, found ignore-2.19.txt with 17 statement(s)
Collection loading complete
Importer processing completed successfully
```