### PR TITLE
Fix for ansible cert issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,6 @@ This example outlines how to use Ansible to install or upgrade the software imag
 
 [Please refer Funcational Tests](https://github.com/Juniper/ansible-junos-stdlib/tree/master/tests#readme)
 
-## SUPPORT
-
-As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
-
 ## Release Notes and Roadmap
 
 [Release Notes](https://github.com/Juniper/ansible-junos-stdlib/blob/master/ansible_collections/juniper/device/CHANGELOG.rst)

--- a/ansible_collections/juniper/device/CHANGELOG.rst
+++ b/ansible_collections/juniper/device/CHANGELOG.rst
@@ -10,13 +10,13 @@ Version 2.0.0 (2025-10-30)
 ---------------------------
 Enhancements
 ------------
-Juniper Networks and RedHat Ansible have combined their Ansible collections for managing Juniper devices. This release merges Ansible’s collection into the Juniper collection, providing customers with a single curated set of modules.
+Juniper Networks and RedHat Ansible have combined their Ansible collections for managing Juniper devices. This release merges Ansible collection into the Juniper collection, providing customers with a single curated set of modules.
 
 
 The Combined collection is available under single namespace juniper.device
 
 
-List of supported modules from Juniper's collection:
+List of supported modules from Juniper collection:
 
 - command
 - config
@@ -32,7 +32,7 @@ List of supported modules from Juniper's collection:
 - table
 
 
-List of supported modules from Ansible's collection:
+List of supported modules from Ansible collection:
 
 
 - junos_acl_interfaces

--- a/ansible_collections/juniper/device/README.md
+++ b/ansible_collections/juniper/device/README.md
@@ -163,10 +163,6 @@ This example outlines how to use Ansible to install or upgrade the software imag
 
 [Please refer Funcational Tests](https://github.com/Juniper/ansible-junos-stdlib/tree/master/tests#readme)
 
-## SUPPORT
-
-As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner. If a support case cannot be opened with Red Hat and the collection has been obtained either from Galaxy or GitHub, there may community help available on the [Ansible Forum](https://forum.ansible.com/).
-
 ## Release Notes and Roadmap
 
 [Release Notes](https://github.com/Juniper/ansible-junos-stdlib/blob/master/ansible_collections/juniper/device/CHANGELOG.rst)

--- a/ansible_collections/juniper/device/plugins/modules/file_copy.py
+++ b/ansible_collections/juniper/device/plugins/modules/file_copy.py
@@ -184,7 +184,7 @@ def main():
         else:
             remote_file = params["remote_dir"] + "/" + params["file"]
         if protocol == "scp":
-            if check_sum is False:
+            if not check_sum:
                 output = junos_module.scp_file_copy_put_without_checksum(
                     local_file,
                     remote_file,
@@ -192,7 +192,7 @@ def main():
             else:
                 output = junos_module.scp_file_copy_put(local_file, remote_file)
         elif protocol == "ftp":
-            if check_sum is False:
+            if not check_sum:
                 output = junos_module.ftp_file_copy_put_without_checksum(
                     local_file,
                     remote_file,
@@ -208,7 +208,7 @@ def main():
         else:
             local_file = params["local_dir"] + "/" + params["file"]
         if params["protocol"] == "scp":
-            if check_sum is False:
+            if not check_sum:
                 output = junos_module.scp_file_copy_get_without_checksum(
                     remote_file,
                     local_file,
@@ -216,7 +216,7 @@ def main():
             else:
                 output = junos_module.scp_file_copy_get(remote_file, local_file)
         elif params["protocol"] == "ftp":
-            if check_sum is False:
+            if not check_sum:
                 output = junos_module.ftp_file_copy_get_without_checksum(
                     remote_file,
                     local_file,

--- a/ansible_collections/juniper/device/plugins/modules/junos_static_routes.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_static_routes.py
@@ -265,9 +265,22 @@ EXAMPLES = """
 # commands:
 #   - >-
 #     <nc:routing-options
-#     xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:static><nc:route
-#     delete="delete"><nc:name>192.168.47.0/24</nc:name></nc:route><nc:route
-#     delete="delete"><nc:name>192.168.16.0/24</nc:name></nc:route></nc:static><nc:static><nc:route><nc:name>192.168.16.0/24</nc:name><nc:next-hop>172.16.0.1</nc:next-hop></nc:route></nc:static></nc:routing-options>
+#       xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+#       <nc:static>
+#         <nc:route delete="delete">
+#           <nc:name>192.168.47.0/24</nc:name>
+#         </nc:route>
+#         <nc:route delete="delete">
+#           <nc:name>192.168.16.0/24</nc:name>
+#         </nc:route>
+#       </nc:static>
+#       <nc:static>
+#         <nc:route>
+#           <nc:name>192.168.16.0/24</nc:name>
+#           <nc:next-hop>172.16.0.1</nc:next-hop>
+#         </nc:route>
+#       </nc:static>
+#     </nc:routing-options>
 #   - '<nc:routing-instances xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>'
 # after:
 #   - address_families:
@@ -323,8 +336,19 @@ EXAMPLES = """
 # commands:
 #   - >-
 #     <nc:routing-options
-#     xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:static><nc:route
-#     delete="delete"><nc:name>192.168.47.0/24</nc:name></nc:route></nc:static><nc:static><nc:route><nc:name>192.168.47.0/24</nc:name><nc:next-hop>10.200.16.2</nc:next-hop></nc:route></nc:static></nc:routing-options>
+#       xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">
+#       <nc:static>
+#         <nc:route delete="delete">
+#           <nc:name>192.168.47.0/24</nc:name>
+#         </nc:route>
+#       </nc:static>
+#       <nc:static>
+#         <nc:route>
+#           <nc:name>192.168.47.0/24</nc:name>
+#           <nc:next-hop>10.200.16.2</nc:next-hop>
+#         </nc:route>
+#       </nc:static>
+#     </nc:routing-options>
 #   - '<nc:routing-instances xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>'
 # after:
 #   - address_families:


### PR DESCRIPTION
Addressed following review comments:

1.	README Formatting Issue
- The README currently contains two separate “Support” sections (one labeled SUPPORT and the other Support).
- These need to be merged into a single section.
2.	Ansible Lint Errors
•	Truthy value error in:
o	plugins/modules/file_copy.py
•	Line-length violations in:
o	plugins/modules/junos_static_routes.py
3.	Sanity Check Failure (Blocker)
•	The no-smart-quotes sanity error is currently blocking certification of the collection.
