### PR TITLE
Update examples section with YAML truthy values

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/file_copy.py
+++ b/ansible_collections/juniper/device/plugins/modules/file_copy.py
@@ -109,7 +109,7 @@ EXAMPLES = """
         remote_dir: /var/log
         local_dir: /tmp
         action: get
-        checksum: True
+        checksum: true
         file: log.txt
     - name: Copy a local file into /var/tmp on the remote device
       juniper.device.file_copy:
@@ -117,7 +117,7 @@ EXAMPLES = """
         remote_dir: /var/tmp
         local_dir: /tmp
         action: put
-        checksum: False
+        checksum: false
         file: license.txt
 """
 


### PR DESCRIPTION
ansible-lint warns that truthy values should be true / false because the examples section contains YAML strings.

Observed this in the import logs for the collection upload to Automation Hub at: https://console.redhat.com/ansible/automation-hub/my-imports/?namespace=juniper