### PR TITLE
Fix for file_copy documentation

### DIFF
--- a/ansible_collections/juniper/device/docs/file_copy.rst
+++ b/ansible_collections/juniper/device/docs/file_copy.rst
@@ -15,7 +15,7 @@ Synopsis
 --------
 
 
-* Copy file over SCP to and from a Juniper device
+* Copy file over SCP/FTP to and from a Juniper device
 
 
 .. _module-specific-options-label:
@@ -42,9 +42,20 @@ The following options may be specified for this module:
     <td>str</td>
     <td>yes</td>
     <td></td>
-    <td></td>
+    <td>put, get</td>
     <td>
         <div>Type of operation to execute, currently only support get and put</div>
+    </td>
+    </tr>
+
+    <tr>
+    <td>checksum<br/><div style="font-size: small;"></div></td>
+    <td>bool</td>
+    <td>no</td>
+    <td>True</td>
+    <td></td>
+    <td>
+        <div>Validate the file using MD5 algorithm check</div>
     </td>
     </tr>
 
@@ -71,6 +82,17 @@ The following options may be specified for this module:
     </tr>
 
     <tr>
+    <td>protocol<br/><div style="font-size: small;"></div></td>
+    <td>str</td>
+    <td>no</td>
+    <td>scp</td>
+    <td>scp, ftp</td>
+    <td>
+        <div>Set the protocol to transfer the file</div>
+    </td>
+    </tr>
+
+    <tr>
     <td>remote_dir<br/><div style="font-size: small;"></div></td>
     <td>str</td>
     <td>yes</td>
@@ -78,6 +100,17 @@ The following options may be specified for this module:
     <td></td>
     <td>
         <div>path of the directory on the remote device where the file is located or needs to be copied to</div>
+    </td>
+    </tr>
+
+    <tr>
+    <td>transfer_filename<br/><div style="font-size: small;"></div></td>
+    <td>str</td>
+    <td>no</td>
+    <td></td>
+    <td></td>
+    <td>
+        <div>Name of the transfer file to copy to/from the remote device. If not specified, the value of <em>file</em> is used.</div>
     </td>
     </tr>
 
@@ -100,16 +133,28 @@ Examples
       tasks:
         - name: Copy a log file on a remote device locally
           juniper.device.file_copy:
+            protocol: scp
             remote_dir: /var/log
             local_dir: /tmp
             action: get
+            checksum: true
             file: log.txt
         - name: Copy a local file into /var/tmp on the remote device
           juniper.device.file_copy:
+            protocol: ftp
+            remote_dir: /var/tmp
+            local_dir: /tmp
+            action: put
+            checksum: false
+            file: license.txt
+        - name: Copy a local file to the remote device with a different filename
+          juniper.device.file_copy:
+            protocol: scp
             remote_dir: /var/tmp
             local_dir: /tmp
             action: put
             file: license.txt
+            transfer_filename: license_copy.txt
 
 
 


### PR DESCRIPTION
Fix for file_copy documentation to add the parameters as per https://github.com/Juniper/ansible-junos-stdlib/pull/735
Fix for issue #800 