### PR TITLE
Fix for UnboundLocalError: cannot access local variable 'resp' ...

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/rpc.py
+++ b/ansible_collections/juniper/device/plugins/modules/rpc.py
@@ -593,24 +593,24 @@ def main():
         text_output = None
         parsed_output = None
         if resp is None:
-          # Some operational RPCs (for example file-delete) can return an
-          # empty <rpc-reply/>. Treat that as a successful no-content reply.
-          if rpc_string == "file-delete":
-            text_output = ""
-            resp = True
-            result["msg"] = "The RPC executed successfully with an empty reply."
-            junos_module.logger.debug(
-              "RPC '%s' returned an empty reply; treating as success.",
-              rpc_string,
-            )
-          else:
-            result["msg"] = "RPC execution returned no response object."
-            results.append(result)
-            junos_module.logger.debug(
-              "RPC '%s' returned no response object.",
-              rpc_string,
-            )
-            continue
+            # Some operational RPCs (for example file-delete) can return an
+            # empty <rpc-reply/>. Treat that as a successful no-content reply.
+            if rpc_string == "file-delete":
+                text_output = ""
+                resp = True
+                result["msg"] = "The RPC executed successfully with an empty reply."
+                junos_module.logger.debug(
+                    "RPC '%s' returned an empty reply; treating as success.",
+                    rpc_string,
+                )
+            else:
+                result["msg"] = "RPC execution returned no response object."
+                results.append(result)
+                junos_module.logger.debug(
+                    "RPC '%s' returned no response object.",
+                    rpc_string,
+                )
+                continue
         if resp is True:
             text_output = ""
         elif (isinstance(resp, junos_module.etree._Element)) or (

--- a/ansible_collections/juniper/device/plugins/modules/rpc.py
+++ b/ansible_collections/juniper/device/plugins/modules/rpc.py
@@ -592,6 +592,25 @@ def main():
 
         text_output = None
         parsed_output = None
+        if resp is None:
+          # Some operational RPCs (for example file-delete) can return an
+          # empty <rpc-reply/>. Treat that as a successful no-content reply.
+          if rpc_string == "file-delete":
+            text_output = ""
+            resp = True
+            result["msg"] = "The RPC executed successfully with an empty reply."
+            junos_module.logger.debug(
+              "RPC '%s' returned an empty reply; treating as success.",
+              rpc_string,
+            )
+          else:
+            result["msg"] = "RPC execution returned no response object."
+            results.append(result)
+            junos_module.logger.debug(
+              "RPC '%s' returned no response object.",
+              rpc_string,
+            )
+            continue
         if resp is True:
             text_output = ""
         elif (isinstance(resp, junos_module.etree._Element)) or (

--- a/ansible_collections/juniper/device/plugins/modules/rpc.py
+++ b/ansible_collections/juniper/device/plugins/modules/rpc.py
@@ -566,9 +566,9 @@ def main():
                         )
                     except Exception as ex:
                         if "RpcError" in (str(ex)):
-                            raise junos_module.pyez_exception.RpcError(str(ex)
+                            raise junos_module.pyez_exception.RpcError(str(ex))
                         if "ConnectError" in (str(ex)):
-                            raise junos_module.pyez_exception.ConnectError(str(ex)
+                            raise junos_module.pyez_exception.ConnectError(str(ex))
                 result["msg"] = "The RPC executed successfully."
                 junos_module.logger.debug(
                     'RPC "%s" executed successfully.',

--- a/ansible_collections/juniper/device/plugins/modules/rpc.py
+++ b/ansible_collections/juniper/device/plugins/modules/rpc.py
@@ -497,6 +497,7 @@ def main():
             "changed": False,
             "failed": True,
         }
+        resp = None
 
         # Execute the RPC
         try:
@@ -565,9 +566,9 @@ def main():
                         )
                     except Exception as ex:
                         if "RpcError" in (str(ex)):
-                            raise junos_module.pyez_exception.RpcError
+                            raise junos_module.pyez_exception.RpcError(str(ex)
                         if "ConnectError" in (str(ex)):
-                            raise junos_module.pyez_exception.ConnectError
+                            raise junos_module.pyez_exception.ConnectError(str(ex)
                 result["msg"] = "The RPC executed successfully."
                 junos_module.logger.debug(
                     'RPC "%s" executed successfully.',


### PR DESCRIPTION
As described in issue #821, running the file-delete RPC can return module failure output that includes:

- `No start of json char found`
- `UnboundLocalError: cannot access local variable 'resp' ...`

This pull request fixes both issues by initializing `resp` before RPC execution.

In addition, some RPC operations such as `file-delete` may return an empty reply body. Previously this could lead to `Unexpected response type <class 'NoneType'>`. This change adds explicit handling for an empty `file-delete` reply so the task is treated as successful, without requiring `failed_when: false`.

Using the playbook from issue #821, with the following playbook change:

```yaml
    - name: DELETE file from device (RPC file-delete)                                           
      juniper.device.rpc:                                                                       
        rpc: file-delete                                                                        
        kwargs:                                                                                 
          path: "{{ jmuse_remote_path }}"                                                       
      register: jmuse_delete_result                                                             
      changed_when: true 
```

The playbook now runs without failures:

```text
TASK [PUT file to device] ********************************************************************
changed: [srx]

TASK [DELETE file from device (RPC file-delete)] *********************************************
changed: [srx]

TASK [Verify file no longer exists] **********************************************************
ok: [srx]

TASK [Show RPC delete summary] ***************************************************************
ok: [srx] => {
    "msg": {
        "contains_json_start_error": false,
        "contains_unbound_local_error": false,
        "delete_exception": "",
        "delete_failed": false,
        "delete_module_stderr": "",
        "delete_msg": "The RPC executed successfully with an empty reply.",
        "put_failed": false,
        "remote_path": "/var/tmp/jmuse-dev-bug-rpc-20260506T093003.txt",
        "verify_output": "\n/var/tmp/jmuse-dev-bug-rpc-20260506T093003.txt: No such file or directory\n"
    }
}
```
