### PR TITLE
Supported commit comment parameter

### DIFF
--- a/.github/skills/generate-test-cases/SKILL.md
+++ b/.github/skills/generate-test-cases/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: generate-test-cases-junos
+description: "Use when source code changes under ansible_collections/juniper/device/plugins and the user wants unit tests created or updated under ansible_collections/junipernetworks/junos/tests/unit."
+allowed-tools:
+  - read_file
+  - file_search
+  - grep_search
+  - run_in_terminal
+  - apply_patch
+  - get_errors
+context: fork
+---
+
+# Generate Unit Tests For Junos Collection Changes
+
+## Goal
+Create or update unit tests for code changes under:
+- ansible_collections/juniper/device/plugins/module_utils/network/junos
+- ansible_collections/juniper/device/plugins/modules
+
+Match the existing test style under:
+- ansible_collections/junipernetworks/junos/tests/unit
+
+## Use This Skill When
+- The user asks to write unit tests for modified Junos collection source files.
+- The requested scope is under ansible_collections/juniper/device/plugins.
+- The user expects actual test file edits, not only planning.
+
+## Do Not Use This Skill When
+- The task is test planning only (no code edits requested).
+- The task is integration/functional testing under tests/integration.
+
+## Required Workflow
+
+### 1) Detect changed source files
+Collect changed files and keep only these roots:
+- ansible_collections/juniper/device/plugins/module_utils/network/junos
+- ansible_collections/juniper/device/plugins/modules
+
+Preferred commands:
+- git diff --name-only -- ansible_collections/juniper/device/plugins/module_utils/network/junos ansible_collections/juniper/device/plugins/modules
+- git diff --name-only --cached -- ansible_collections/juniper/device/plugins/module_utils/network/junos ansible_collections/juniper/device/plugins/modules
+
+If both are empty, ask for exact files or compare branch heads:
+- git diff --name-only origin/master...HEAD -- ansible_collections/juniper/device/plugins/module_utils/network/junos ansible_collections/juniper/device/plugins/modules
+
+### 2) Map source file to unit test path
+Use these conventions first, then adjust to existing repository layout:
+
+- ansible_collections/juniper/device/plugins/modules/junos_<name>.py
+  -> ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_<name>.py
+
+- ansible_collections/juniper/device/plugins/module_utils/network/junos/config/<name>/<name>.py
+  -> ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_<name>.py
+
+- ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/<name>/<name>.py
+  -> ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_<name>.py
+
+- ansible_collections/juniper/device/plugins/module_utils/network/junos/config/<name>/
+  + ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/<name>/
+  + ansible_collections/juniper/device/plugins/modules/junos_<name>.py
+  -> prefer updating one existing test file test_junos_<name>.py
+
+If no matching test file exists, create one at:
+- ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_<name>.py
+
+### 3) Learn local style before writing tests
+Read nearby tests and follow conventions:
+- unittest-style classes inheriting from TestJunosModule.
+- setUp patches for lock/unlock/load/commit and facts collection.
+- set_module_args(...) + execute_module(...) pattern.
+- fixture usage via load_fixture(...).
+
+### 4) Implement behavior-focused tests only for changed behavior
+Cover only behavior changed by source diff.
+
+Typical scenarios for these modules:
+- New parameter accepted by module args and not rejected.
+- Parameter passed to commit_configuration kwargs when changed config commits.
+- Default behavior path if parameter omitted.
+- Error/edge path only if the source diff changed validation behavior.
+
+Do not over-assert internal details unrelated to observable behavior.
+
+### 5) Keep edits minimal and scoped
+- Do not refactor unrelated tests.
+- Do not reformat unrelated files.
+- Reuse existing fixtures/helpers first.
+
+### 6) Validate with targeted runs first
+Run only updated/generated test files first.
+
+Preferred commands:
+- python -m pytest -q ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_<name>.py
+- python -m pytest -q ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_<name>.py -k <new_test_name>
+
+Then optionally run broader subset:
+- python -m pytest -q ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos
+
+### 7) Report results
+Summarize:
+- changed source files detected
+- source-to-test mapping used
+- test files created/updated
+- scenarios covered
+- command(s) run and pass/fail outcome
+- residual risks or uncovered branches
+
+## Output Contract
+Final response must include:
+1. Source-to-test mapping used.
+2. Exact test files modified.
+3. Behavior each new/updated test verifies.
+4. Validation command summary and outcomes.
+5. Test output excerpt (at least test status lines + final summary).

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
@@ -65,7 +65,6 @@ class Acl_interfacesArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_acl_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
@@ -64,6 +64,11 @@ class Acl_interfacesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_acl_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acls/acls.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acls/acls.py
@@ -193,7 +193,6 @@ class AclsArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_acls",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acls/acls.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acls/acls.py
@@ -192,6 +192,11 @@ class AclsArgs(object):  # pylint: disable=R0903
             },
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_acls",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_address_family/bgp_address_family.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_address_family/bgp_address_family.py
@@ -879,7 +879,6 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_bgp_address_family",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_address_family/bgp_address_family.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_address_family/bgp_address_family.py
@@ -878,6 +878,11 @@ class Bgp_address_familyArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_bgp_address_family",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
@@ -1255,6 +1255,11 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_bgp_global",
+        },
         "state": {
             "choices": [
                 "purged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
@@ -1256,7 +1256,6 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_bgp_global",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/hostname/hostname.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/hostname/hostname.py
@@ -40,6 +40,11 @@ class HostnameArgs(object):  # pylint: disable=R0903
     argument_spec = {
         "config": {"options": {"hostname": {"type": "str"}}, "type": "dict"},
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_hostname",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/hostname/hostname.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/hostname/hostname.py
@@ -41,7 +41,6 @@ class HostnameArgs(object):  # pylint: disable=R0903
         "config": {"options": {"hostname": {"type": "str"}}, "type": "dict"},
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_hostname",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
@@ -70,6 +70,11 @@ class InterfacesArgs(object):
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
@@ -71,7 +71,6 @@ class InterfacesArgs(object):
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
@@ -60,7 +60,6 @@ class L2_interfacesArgs(object):
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_l2_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
@@ -59,6 +59,11 @@ class L2_interfacesArgs(object):
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_l2_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -39,6 +39,11 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_l3_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -40,7 +40,6 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_l3_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp/lacp.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp/lacp.py
@@ -50,7 +50,6 @@ class LacpArgs(object):
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_lacp",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp/lacp.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp/lacp.py
@@ -49,6 +49,11 @@ class LacpArgs(object):
             },
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_lacp",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp_interfaces/lacp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp_interfaces/lacp_interfaces.py
@@ -63,6 +63,11 @@ class Lacp_interfacesArgs(object):
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_lacp_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp_interfaces/lacp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lacp_interfaces/lacp_interfaces.py
@@ -64,7 +64,6 @@ class Lacp_interfacesArgs(object):
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_lacp_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
@@ -61,6 +61,11 @@ class Lag_interfacesArgs(object):
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_lag_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
@@ -62,7 +62,6 @@ class Lag_interfacesArgs(object):
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_lag_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_global/lldp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_global/lldp_global.py
@@ -49,6 +49,11 @@ class Lldp_globalArgs(object):
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_lldp_global",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_global/lldp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_global/lldp_global.py
@@ -50,7 +50,6 @@ class Lldp_globalArgs(object):
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_lldp_global",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
@@ -48,7 +48,6 @@ class Lldp_interfacesArgs(object):
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_lldp_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/lldp_interfaces/lldp_interfaces.py
@@ -47,6 +47,11 @@ class Lldp_interfacesArgs(object):
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_lldp_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/logging_global/logging_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/logging_global/logging_global.py
@@ -1365,7 +1365,6 @@ class Logging_globalArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_logging_global",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/logging_global/logging_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/logging_global/logging_global.py
@@ -1364,6 +1364,11 @@ class Logging_globalArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_logging_global",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ntp_global/ntp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ntp_global/ntp_global.py
@@ -118,7 +118,6 @@ class Ntp_globalArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_ntp_global",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ntp_global/ntp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ntp_global/ntp_global.py
@@ -117,6 +117,11 @@ class Ntp_globalArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_ntp_global",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
@@ -127,7 +127,6 @@ class Ospf_interfacesArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_ospf_interfaces",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
@@ -126,6 +126,11 @@ class Ospf_interfacesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_ospf_interfaces",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv2/ospfv2.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv2/ospfv2.py
@@ -143,6 +143,11 @@ class Ospfv2Args(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_ospfv2",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv2/ospfv2.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv2/ospfv2.py
@@ -144,7 +144,6 @@ class Ospfv2Args(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_ospfv2",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv3/ospfv3.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv3/ospfv3.py
@@ -110,7 +110,6 @@ class Ospfv3Args(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_ospfv3",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv3/ospfv3.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/ospfv3/ospfv3.py
@@ -109,6 +109,11 @@ class Ospfv3Args(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_ospfv3",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/prefix_lists/prefix_lists.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/prefix_lists/prefix_lists.py
@@ -47,6 +47,11 @@ class Prefix_listsArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_prefix_lists",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/prefix_lists/prefix_lists.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/prefix_lists/prefix_lists.py
@@ -48,7 +48,6 @@ class Prefix_listsArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_prefix_lists",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_instances/routing_instances.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_instances/routing_instances.py
@@ -108,6 +108,11 @@ class Routing_instancesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_routing_instances",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_instances/routing_instances.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_instances/routing_instances.py
@@ -109,7 +109,6 @@ class Routing_instancesArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_routing_instances",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_options/routing_options.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_options/routing_options.py
@@ -53,6 +53,11 @@ class Routing_optionsArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_routing_options",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_options/routing_options.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/routing_options/routing_options.py
@@ -54,7 +54,6 @@ class Routing_optionsArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_routing_options",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies/security_policies.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies/security_policies.py
@@ -807,7 +807,6 @@ class Security_policiesArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_security_policies",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies/security_policies.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies/security_policies.py
@@ -806,6 +806,11 @@ class Security_policiesArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_security_policies",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies_global/security_policies_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies_global/security_policies_global.py
@@ -114,7 +114,6 @@ class Security_policies_globalArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_security_policies_global",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies_global/security_policies_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_policies_global/security_policies_global.py
@@ -113,6 +113,11 @@ class Security_policies_globalArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_security_policies_global",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_zones/security_zones.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_zones/security_zones.py
@@ -176,6 +176,11 @@ class Security_zonesArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_security_zones",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_zones/security_zones.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/security_zones/security_zones.py
@@ -177,7 +177,6 @@ class Security_zonesArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_security_zones",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/snmp_server/snmp_server.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/snmp_server/snmp_server.py
@@ -684,6 +684,11 @@ class Snmp_serverArgs(object):  # pylint: disable=R0903
             "type": "dict",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_snmp_server",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/snmp_server/snmp_server.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/snmp_server/snmp_server.py
@@ -685,7 +685,6 @@ class Snmp_serverArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_snmp_server",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
@@ -75,7 +75,6 @@ class Static_routesArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_static_routes",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
@@ -74,6 +74,11 @@ class Static_routesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_static_routes",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/vlans/vlans.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/vlans/vlans.py
@@ -49,6 +49,11 @@ class VlansArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "running_config": {"type": "str"},
+        "comment": {
+            "description": "Commit comment for the configuration change",
+            "type": "str",
+            "default": "configured by junos_vlans",
+        },
         "state": {
             "choices": [
                 "merged",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/vlans/vlans.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/vlans/vlans.py
@@ -50,7 +50,6 @@ class VlansArgs(object):  # pylint: disable=R0903
         },
         "running_config": {"type": "str"},
         "comment": {
-            "description": "Commit comment for the configuration change",
             "type": "str",
             "default": "configured by junos_vlans",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
@@ -108,7 +108,10 @@ class Acl_interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acls/acls.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acls/acls.py
@@ -106,7 +106,10 @@ class Acls(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_address_family/bgp_address_family.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_address_family/bgp_address_family.py
@@ -112,7 +112,10 @@ class Bgp_address_family(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
@@ -106,7 +106,10 @@ class Bgp_global(ConfigBase):
                 commit = not self._module.check_mode
                 if config_xmls and diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/hostname/hostname.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/hostname/hostname.py
@@ -107,7 +107,10 @@ class Hostname(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
@@ -104,7 +104,10 @@ class Interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
@@ -111,7 +111,10 @@ class L2_interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
@@ -108,7 +108,10 @@ class L3_interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lacp/lacp.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lacp/lacp.py
@@ -105,7 +105,10 @@ class Lacp(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
@@ -107,7 +107,10 @@ class Lacp_interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
@@ -110,7 +110,10 @@ class Lag_interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lldp_global/lldp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lldp_global/lldp_global.py
@@ -103,7 +103,10 @@ class Lldp_global(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/lldp_interfaces/lldp_interfaces.py
@@ -107,7 +107,10 @@ class Lldp_interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/logging_global/logging_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/logging_global/logging_global.py
@@ -111,7 +111,10 @@ class Logging_global(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ntp_global/ntp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ntp_global/ntp_global.py
@@ -107,7 +107,10 @@ class Ntp_global(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
@@ -112,7 +112,10 @@ class Ospf_interfaces(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ospfv2/ospfv2.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ospfv2/ospfv2.py
@@ -118,7 +118,10 @@ class Ospfv2(ConfigBase):
                 commit = not self._module.check_mode
                 if config_xmls and diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ospfv3/ospfv3.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/ospfv3/ospfv3.py
@@ -118,7 +118,10 @@ class Ospfv3(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/prefix_lists/prefix_lists.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/prefix_lists/prefix_lists.py
@@ -109,7 +109,10 @@ class Prefix_lists(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/routing_instances/routing_instances.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/routing_instances/routing_instances.py
@@ -110,7 +110,10 @@ class Routing_instances(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/routing_options/routing_options.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/routing_options/routing_options.py
@@ -111,7 +111,10 @@ class Routing_options(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/security_policies/security_policies.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/security_policies/security_policies.py
@@ -110,7 +110,10 @@ class Security_policies(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/security_policies_global/security_policies_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/security_policies_global/security_policies_global.py
@@ -114,7 +114,10 @@ class Security_policies_global(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/security_zones/security_zones.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/security_zones/security_zones.py
@@ -110,7 +110,10 @@ class Security_zones(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/snmp_server/snmp_server.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/snmp_server/snmp_server.py
@@ -109,7 +109,10 @@ class Snmp_server(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/static_routes/static_routes.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/static_routes/static_routes.py
@@ -108,7 +108,10 @@ class Static_routes(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/vlans/vlans.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/vlans/vlans.py
@@ -114,7 +114,10 @@ class Vlans(ConfigBase):
                 commit = not self._module.check_mode
                 if diff:
                     if commit:
-                        commit_configuration(self._module)
+                        kwargs = {
+                            "comment": self._module.params.get("comment"),
+                        }
+                        commit_configuration(self._module, **kwargs)
                     else:
                         discard_changes(self._module)
                     result["changed"] = True

--- a/ansible_collections/juniper/device/plugins/modules/_tbrdevice_hostname.py
+++ b/ansible_collections/juniper/device/plugins/modules/_tbrdevice_hostname.py
@@ -61,6 +61,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_hostname
   config:
     description: A dictionary of system Hostname configuration.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
@@ -93,6 +93,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_acl_interfaces
   state:
     description:
     - The state the configuration should be left in.

--- a/ansible_collections/juniper/device/plugins/modules/junos_acls.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_acls.py
@@ -253,6 +253,12 @@ options:
         transforms it into Ansible structured data as per the resource module's argspec
         and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_acls
   state:
     description:
     - The state the configuration should be left in

--- a/ansible_collections/juniper/device/plugins/modules/junos_bgp_address_family.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_bgp_address_family.py
@@ -61,6 +61,12 @@ options:
         transforms it into Ansible structured data as per the resource module's argspec
         and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_bgp_address_family
   config:
     description: The provided link BGP address family dictionary.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_bgp_global.py
@@ -62,6 +62,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_bgp_global
   config:
     description: A list of BGP process configuration.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_hostname.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_hostname.py
@@ -61,6 +61,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_hostname
   config:
     description: A dictionary of system Hostname configuration.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_interfaces.py
@@ -114,6 +114,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_interfaces
   state:
     choices:
     - merged

--- a/ansible_collections/juniper/device/plugins/modules/junos_l2_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_l2_interfaces.py
@@ -94,6 +94,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_l2_interfaces
   state:
     choices:
     - merged

--- a/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
@@ -103,6 +103,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_l3_interfaces
   state:
     description:
     - The state of the configuration after module completion

--- a/ansible_collections/juniper/device/plugins/modules/junos_lacp.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_lacp.py
@@ -67,17 +67,23 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+      - Commit comment to be associated with the configuration changes.
+      - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_lacp
   state:
     description:
-    - The state of the configuration after module completion
+      - The state of the configuration after module completion
     type: str
     choices:
-    - merged
-    - replaced
-    - deleted
-    - gathered
-    - rendered
-    - parsed
+      - merged
+      - replaced
+      - deleted
+      - gathered
+      - rendered
+      - parsed
     default: merged
 requirements:
 - ncclient (>=v0.6.4)

--- a/ansible_collections/juniper/device/plugins/modules/junos_lacp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_lacp_interfaces.py
@@ -112,12 +112,14 @@ options:
     - The state I(parsed) reads the configuration from C(running_config) option and
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
-    type: str  comment:
+    type: str
+  comment:
     description:
     - Commit comment to be associated with the configuration changes.
     - This allows tracking the reason for configuration changes (e.g., change management ticket).
     type: str
-    default: configured by junos_lacp_interfaces  state:
+    default: configured by junos_lacp_interfaces
+  state:
     description:
     - The state of the configuration after module completion.
     type: str

--- a/ansible_collections/juniper/device/plugins/modules/junos_lacp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_lacp_interfaces.py
@@ -112,8 +112,12 @@ options:
     - The state I(parsed) reads the configuration from C(running_config) option and
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
+    type: str  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
     type: str
-  state:
+    default: configured by junos_lacp_interfaces  state:
     description:
     - The state of the configuration after module completion.
     type: str

--- a/ansible_collections/juniper/device/plugins/modules/junos_lag_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_lag_interfaces.py
@@ -100,8 +100,12 @@ options:
     - The state I(parsed) reads the configuration from C(running_config) option and
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
+    type: str  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
     type: str
-  state:
+    default: configured by junos_lag_interfaces  state:
     description:
     - The state of the configuration after module completion
     type: str

--- a/ansible_collections/juniper/device/plugins/modules/junos_lag_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_lag_interfaces.py
@@ -100,12 +100,14 @@ options:
     - The state I(parsed) reads the configuration from C(running_config) option and
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
-    type: str  comment:
+    type: str
+  comment:
     description:
     - Commit comment to be associated with the configuration changes.
     - This allows tracking the reason for configuration changes (e.g., change management ticket).
     type: str
-    default: configured by junos_lag_interfaces  state:
+    default: configured by junos_lag_interfaces
+  state:
     description:
     - The state of the configuration after module completion
     type: str

--- a/ansible_collections/juniper/device/plugins/modules/junos_lldp_global.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_lldp_global.py
@@ -77,17 +77,23 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+      - Commit comment to be associated with the configuration changes.
+      - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_lldp_global
   state:
     description:
-    - The state of the configuration after module completion.
+      - The state of the configuration after module completion.
     type: str
     choices:
-    - merged
-    - replaced
-    - deleted
-    - gathered
-    - rendered
-    - parsed
+      - merged
+      - replaced
+      - deleted
+      - gathered
+      - rendered
+      - parsed
     default: merged
 requirements:
 - ncclient (>=v0.6.4)

--- a/ansible_collections/juniper/device/plugins/modules/junos_lldp_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_lldp_interfaces.py
@@ -64,18 +64,24 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+      - Commit comment to be associated with the configuration changes.
+      - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_lldp_interfaces
   state:
     description:
-    - The state of the configuration after module completion.
+      - The state of the configuration after module completion.
     type: str
     choices:
-    - merged
-    - replaced
-    - overridden
-    - deleted
-    - gathered
-    - rendered
-    - parsed
+      - merged
+      - replaced
+      - overridden
+      - deleted
+      - gathered
+      - rendered
+      - parsed
     default: merged
 """
 EXAMPLES = """

--- a/ansible_collections/juniper/device/plugins/modules/junos_logging_global.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_logging_global.py
@@ -56,6 +56,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_logging_global
   config:
     description: A dictionary of logging configuration.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_ntp_global.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_ntp_global.py
@@ -55,6 +55,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_ntp_global
   config:
     description: A dictionary of NTP configuration.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_ospf_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_ospf_interfaces.py
@@ -220,6 +220,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_ospf_interfaces
   state:
     description:
       - The state the configuration should be left in.

--- a/ansible_collections/juniper/device/plugins/modules/junos_ospfv2.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_ospfv2.py
@@ -268,6 +268,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_ospfv2
   state:
     description:
     - The state the configuration should be left in.

--- a/ansible_collections/juniper/device/plugins/modules/junos_ospfv3.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_ospfv3.py
@@ -210,6 +210,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_ospfv3
   state:
     description:
     - The state the configuration should be left in.

--- a/ansible_collections/juniper/device/plugins/modules/junos_prefix_lists.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_prefix_lists.py
@@ -62,6 +62,12 @@ options:
         transforms it into Ansible structured data as per the resource module's argspec
         and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_prefix_lists
   config:
     description: The provided link BGP address family dictionary.
     type: list

--- a/ansible_collections/juniper/device/plugins/modules/junos_routing_instances.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_routing_instances.py
@@ -61,6 +61,12 @@ options:
         transforms it into Ansible structured data as per the resource module's argspec
         and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_routing_instances
   config:
     description: The provided Routing instance configuration list.
     type: list

--- a/ansible_collections/juniper/device/plugins/modules/junos_routing_options.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_routing_options.py
@@ -56,6 +56,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_routing_options
   config:
     description: A dictionary of routing-options configuration.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_security_policies.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_security_policies.py
@@ -566,6 +566,12 @@ options:
         transforms it into Ansible structured data as per the resource module's argspec
         and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+      - Commit comment to be associated with the configuration changes.
+      - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_security_policies
   state:
     choices:
     - merged

--- a/ansible_collections/juniper/device/plugins/modules/junos_security_policies_global.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_security_policies_global.py
@@ -187,15 +187,21 @@ options:
         transforms it into Ansible structured data as per the resource module's argspec
         and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+      - Commit comment to be associated with the configuration changes.
+      - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_security_policies_global
   state:
     choices:
-    - merged
-    - replaced
-    - overridden
-    - deleted
-    - rendered
-    - gathered
-    - parsed
+      - merged
+      - replaced
+      - overridden
+      - deleted
+      - rendered
+      - gathered
+      - parsed
     default: merged
     description:
       - The state the configuration should be left in

--- a/ansible_collections/juniper/device/plugins/modules/junos_security_zones.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_security_zones.py
@@ -261,6 +261,12 @@ options:
         transforms it into Ansible structured data as per the resource module's argspec
         and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+      - Commit comment to be associated with the configuration changes.
+      - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_security_zones
   state:
     choices:
     - merged

--- a/ansible_collections/juniper/device/plugins/modules/junos_snmp_server.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_snmp_server.py
@@ -62,6 +62,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result.
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_snmp_server
   config:
     description: A dictionary of SNMP server configuration.
     type: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_static_routes.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_static_routes.py
@@ -102,6 +102,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_static_routes
   state:
     description:
     - The state the configuration should be left in

--- a/ansible_collections/juniper/device/plugins/modules/junos_vlans.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_vlans.py
@@ -79,6 +79,12 @@ options:
       transforms it into Ansible structured data as per the resource module's argspec
       and the value is then returned in the I(parsed) key within the result
     type: str
+  comment:
+    description:
+    - Commit comment to be associated with the configuration changes.
+    - This allows tracking the reason for configuration changes (e.g., change management ticket).
+    type: str
+    default: configured by junos_vlans
   state:
     description:
     - The state of the configuration after module completion.

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_bgp_address_family.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_bgp_address_family.py
@@ -3088,3 +3088,54 @@ class TestJunosBgp_address_familyModule(TestJunosModule):
 
         self.execute_module(changed=False, commands=[])
     """
+
+    def test_junos_bgp_address_family_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_bgp_address_family.Bgp_address_familyArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_bgp_address_family",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                set_module_args(
+                    dict(
+                        config=dict(
+                            groups=[
+                                dict(
+                                    name="external",
+                                    address_family=[
+                                        dict(
+                                            afi="evpn",
+                                            af_type=[dict(type="flow", damping=True)],
+                                        )
+                                    ],
+                                )
+                            ],
+                            address_family=[
+                                dict(
+                                    afi="evpn",
+                                    af_type=[dict(type="flow", damping=True)],
+                                )
+                            ],
+                        ),
+                        state="merged",
+                    )
+                )
+                self.execute_module(changed=True)
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_bgp_global.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_bgp_global.py
@@ -1188,3 +1188,30 @@ class TestJunosBgp_globalModule(TestJunosModule):
         """
         set_module_args(dict(running_config=parsed_str, state="parsed"))
         self.execute_module(changed=False)
+
+    def test_junos_bgp_global_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_bgp_global.Bgp_globalArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_bgp_global",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_bgp_global_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_hostname.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_hostname.py
@@ -66,6 +66,18 @@ class TestJunosHostnameModule(TestJunosModule):
         )
         self.execute_show_command = self.mock_execute_show_command.start()
 
+        self.mock_comment_argument_spec = patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_hostname.HostnameArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_hostname",
+                },
+            },
+            clear=False,
+        )
+        self.mock_comment_argument_spec.start()
+
     def tearDown(self):
         super(TestJunosHostnameModule, self).tearDown()
         self.mock_load_config.stop()
@@ -73,6 +85,7 @@ class TestJunosHostnameModule(TestJunosModule):
         self.mock_unlock_configuration.stop()
         self.mock_commit_configuration.stop()
         self.mock_execute_show_command.stop()
+        self.mock_comment_argument_spec.stop()
 
     def load_fixtures(
         self,
@@ -93,6 +106,21 @@ class TestJunosHostnameModule(TestJunosModule):
         self.assertIn(
             "<nc:host-name>vsrx</nc:host-name>",
             str(result["commands"]),
+        )
+
+    def test_junos_hostname_merged_comment_01(self):
+        set_module_args(
+            dict(
+                config=dict(hostname="vsrx"),
+                comment="configured via unit test",
+                state="merged",
+            ),
+        )
+        self.execute_module(changed=True)
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
         )
 
     def test_junos_hostname_parsed_01(self):

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
@@ -253,3 +253,30 @@ class TestJunosInterfacesModule(TestJunosModule):
             "</nc:interface></nc:interfaces>",
         ]
         self.execute_module(changed=False, commands=commands)
+
+    def test_junos_interfaces_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_interfaces.InterfacesArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_interfaces",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_interfaces_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l2_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l2_interfaces.py
@@ -314,3 +314,30 @@ class TestJunosL2InterfacesModule(TestJunosModule):
         )
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["rendered"]), sorted(rendered))
+
+    def test_junos_l2_interfaces_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_l2_interfaces.L2_interfacesArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_l2_interfaces",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_l2_interfaces_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l3_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l3_interfaces.py
@@ -254,3 +254,30 @@ class TestJunosL3InterfacesModule(TestJunosModule):
             "</nc:unit></nc:interface></nc:interfaces>",
         ]
         self.execute_module(changed=False, commands=commands)
+
+    def test_junos_l3_interfaces_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_l3_interfaces.L3_interfacesArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_l3_interfaces",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_l3_interfaces_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_logging_global.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_logging_global.py
@@ -1027,3 +1027,30 @@ class TestJunosLogging_globalModule(TestJunosModule):
             ],
         }
         self.assertEqual(sorted(parsed_dict), sorted(result["parsed"]))
+
+    def test_junos_logging_global_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_logging_global.Logging_globalArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_logging_global",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_logging_global_merged_archive_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ntp_global.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ntp_global.py
@@ -716,3 +716,30 @@ class TestJunosNtp_globalModule(TestJunosModule):
             "<nc:name>192.16.255.255</nc:name><nc:key>50</nc:key>",
             str(result["commands"]),
         )
+
+    def test_junos_ntp_global_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_ntp_global.Ntp_globalArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_ntp_global",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_ntp_global_merged_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ospf_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ospf_interfaces.py
@@ -342,3 +342,30 @@ class TestJunosOspfv3Module(TestJunosModule):
             "<nc:router-id>10.200.16.75</nc:router-id></nc:routing-options>",
         ]
         self.execute_module(changed=False, commands=commands)
+
+    def test_junos_ospf_interfaces_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_ospf_interfaces.Ospf_interfacesArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_ospf_interfaces",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_ospf_interfaces_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ospfv2.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ospfv2.py
@@ -809,3 +809,30 @@ class TestJunosOspfv2Module(TestJunosModule):
             self.sorted_xml(result["rendered"]),
             self.sorted_xml(rendered),
         )
+
+    def test_junos_ospfv2_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_ospfv2.Ospfv2Args.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_ospfv2",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_ospfv2_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ospfv3.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_ospfv3.py
@@ -401,3 +401,30 @@ class TestJunosOspfv3Module(TestJunosModule):
             "<nc:default-metric>200</nc:default-metric></nc:stub></nc:area></nc:ospf3></nc:protocols>"
         )
         self.execute_module(changed=False, commands=commands)
+
+    def test_junos_ospfv3_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_ospfv3.Ospfv3Args.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_ospfv3",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_ospfv3_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_prefix_lists.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_prefix_lists.py
@@ -325,3 +325,30 @@ class TestJunosPrefix_listsModule(TestJunosModule):
         )
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["rendered"]), sorted(rendered))
+
+    def test_junos_prefix_lists_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_prefix_lists.Prefix_listsArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_prefix_lists",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_prefix_lists_merged_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_routing_instances.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_routing_instances.py
@@ -488,3 +488,30 @@ class TestJunosRouting_instancesModule(TestJunosModule):
         self.sort_routing_instances(result["parsed"])
         self.sort_routing_instances(parsed_list)
         self.assertEqual(result["parsed"], parsed_list)
+
+    def test_junos_routing_instances_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_routing_instances.Routing_instancesArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_routing_instances",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_routing_instances_domains_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_routing_options.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_routing_options.py
@@ -209,3 +209,30 @@ class TestJunosRouting_optionsModule(TestJunosModule):
             "<nc:autonomous-system>1<nc:loops>4</nc:loops><nc:asdot-notation/>",
             str(result["commands"]),
         )
+
+    def test_junos_routing_options_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_routing_options.Routing_optionsArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_routing_options",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_routing_options_merged_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_security_policies.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_security_policies.py
@@ -1088,3 +1088,30 @@ class TestJunosSecurity_policiesModule(TestJunosModule):
             self.sorted_xml(commands),
             self.sorted_xml(str(result["commands"])),
         )
+
+    def test_junos_security_policies_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_security_policies.Security_policiesArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_security_policies",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_security_policies_merged_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_security_policies_global.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_security_policies_global.py
@@ -636,3 +636,30 @@ class TestJunosSecurity_policies_globalModule(TestJunosModule):
             self.sorted_xml(commands),
             self.sorted_xml(str(result["commands"])),
         )
+
+    def test_junos_security_policies_global_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_security_policies_global.Security_policies_globalArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_security_policies_global",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_security_policies_global_merged_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_security_zones.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_security_zones.py
@@ -1243,3 +1243,30 @@ class TestJunosSecurity_zonesModule(TestJunosModule):
             self.sorted_xml(commands),
             self.sorted_xml(str(result["commands"])),
         )
+
+    def test_junos_security_zones_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_security_zones.Security_zonesArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_security_zones",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_security_zones_merged_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_snmp_server.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_snmp_server.py
@@ -1081,3 +1081,30 @@ class TestJunosSnmp_serverModule(TestJunosModule):
         )
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["rendered"]), sorted(rendered))
+
+    def test_junos_snmp_server_merged_comment_01(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_snmp_server.Snmp_serverArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_snmp_server",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_snmp_server_merged_arp_01()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_vlans.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_vlans.py
@@ -256,3 +256,30 @@ class TestJunosVlansModule(TestJunosModule):
         self.sort_vlans(result["parsed"])
         self.sort_vlans(parsed_list)
         self.assertEqual(result["parsed"], parsed_list)
+
+    def test_junos_vlans_merged_comment_02(self):
+        original_set_module_args = set_module_args
+
+        def _set_module_args_with_comment(args):
+            args = dict(args)
+            args["comment"] = "configured via unit test"
+            return original_set_module_args(args)
+
+        with patch.dict(
+            "ansible_collections.juniper.device.plugins.modules.junos_vlans.VlansArgs.argument_spec",
+            {
+                "comment": {
+                    "type": "str",
+                    "default": "configured by junos_vlans",
+                },
+            },
+            clear=False,
+        ):
+            with patch(__name__ + ".set_module_args", side_effect=_set_module_args_with_comment):
+                self.test_junos_vlans_merged()
+
+        args, kwargs = self.mock_commit_configuration.call_args
+        self.assertEqual(
+            args[0].params.get("comment"),
+            "configured via unit test",
+        )


### PR DESCRIPTION
## Description

Supported commit parameter for each juniperjunos.network

Closes #831 

---

## Collection Namespace

<!-- Identify which collection(s) this PR affects -->

- **Collection namespace:** juniper.device or junipernetworks.junos
- **Collection version (bumped to):** latest
- **Module(s) / plugin(s) changed:** all

---

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature / new module or plugin (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing module or plugin behaviour)
- [ ] Breaking change (fix or feature that would cause existing playbooks / roles to behave differently)
- [ ] Task / Chore (refactor, dependency update, CI, docs, etc.)

---

## Fix Details

Lack of commit comment support for juniper.device modules can require a user to double-commit for one change in order to apply a comment. For example:

juniper.device.junos_vlans is executed and commits, but it does not support a commit comment.
juniper.device.junos_config is subsequently executed to commit with a comment to provide change management information on the prior vlan commit.

Enhanced the juniper. device. modules to support commit comments.

### Root Cause

It's an enhancement to support the commit comment parameter

### Solution
Added a comment argspec parameter in each module


---

## Versions Tested

Latest ansible version

| Item | Version |
|------|---------|
| Collection namespace & version | latest |
| Ansible / ansible-core | latest |
| Python |  3.10.13 |
| OS | Ubuntu 22.04 |
| Junos version | 18.4 |
| Junos platform | vsrx |
| junos-eznc | latest|
| ncclient | latest |

---

## Sanity Test Results

<!-- Run sanity tests and paste the summary output below. -->

- [X] Sanity tests pass with no new errors

```bash
ansible-test sanity
```

<details>
<summary>Sanity test output</summary>

```
Action workflow have an output
```

</details>

---

## Unit Test Results

- [X] New or updated unit tests added under `tests/unit/`
- [X] All unit tests pass locally

```bash
python3.12 -m pytest
```

<details>
<summary>Unit test output</summary>

```
pass
```

</details>

- [X] Code coverage has not decreased

---

## Integration Test Results

<!-- Run integration tests against a real or virtual Junos device and paste the summary. -->

- [ ] Integration tests reviewed for impact
- [ ] Affected integration tests pass (requires a live Junos device or vMX)

```bash
ansible-test network-integration --python 3.12 --inventory /root/pyez_ansible_release_validation1/ansible-junos-stdlib/ansible_collections/juniper/device/tests/integration/inventory.networking
```

<details>
<summary>Integration test output</summary>

```
<paste integration test output here>
```

</details>

---

## Checklist

### Code Quality

- [X] Code follows the project's style guidelines
- [X] `ansible-lint` passes with no new errors

```bash
ansible-lint
```

- [X] `flake8` / `ruff` reports no new errors (for Python files)

```bash
flake8 plugins/
# or
ruff check plugins/
```

### Documentation

- [ ] Module documentation (DOCUMENTATION, EXAMPLES, RETURN blocks) updated if parameters changed
- [ ] `CHANGELOG.rst` / `changelogs/fragments/` entry added
- [ ] `galaxy.yml` version bumped if releasing

### General

- [ ] No hardcoded credentials, IP addresses, or sensitive data introduced
- [ ] `requirements.txt` updated if new Python packages are required
- [ ] Backward-compatible: existing playbooks will not break

---

## Additional Notes

<!-- Anything else reviewers should know: deployment considerations, follow-up tasks, known limitations, related PRs, etc. -->
