### PR TITLE
sw validate default set to True

### DIFF
--- a/ansible_collections/juniper/device/plugins/modules/software.py
+++ b/ansible_collections/juniper/device/plugins/modules/software.py
@@ -278,7 +278,7 @@ options:
       - Whether or not to have the target Junos device should validate the
         current configuration against the new software package.
     required: false
-    default: false
+    default: True
     type: bool
   version:
     description:

--- a/ansible_collections/juniper/device/plugins/modules/software.py
+++ b/ansible_collections/juniper/device/plugins/modules/software.py
@@ -505,7 +505,7 @@ def main():
         issu=dict(required=False, type="bool", default=False),
         nssu=dict(required=False, type="bool", default=False),
         force_host=dict(required=False, type="bool", default=False),
-        validate=dict(required=False, type="bool", default=False),
+        validate=dict(required=False, type="bool", default=True),
         cleanfs=dict(required=False, type="bool", default=True),
         all_re=dict(required=False, type="bool", default=True),
         member_id=dict(required=False, type="list", elements="str", default=None),


### PR DESCRIPTION
Before: 
Ansible software module defaulted to validate: false — unless explicitly set in the playbook, no validation was performed.

After: 
Default is now validate: true — validation runs automatically without any playbook configuration. 

To skip validation, the playbook must explicitly set validate: false.