### PR TITLE
V2.0.4

### DIFF
--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
@@ -60,6 +60,8 @@ class Acl_interfacesArgs(object):  # pylint: disable=R0903
                     "type": "list",
                 },
                 "name": {"type": "str"},
+                "vlan_id": {"type": "int"},
+                "vlan_tagging": {"type": "bool"},
             },
             "type": "list",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/acl_interfaces/acl_interfaces.py
@@ -62,6 +62,11 @@ class Acl_interfacesArgs(object):  # pylint: disable=R0903
                 "name": {"type": "str"},
                 "vlan_id": {"type": "int"},
                 "vlan_tagging": {"type": "bool"},
+                "filter_binding": {
+                    "type": "str",
+                    "choices": ["list", "singular"],
+                    "default": "list",
+                },
             },
             "type": "list",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
@@ -57,12 +57,14 @@ class InterfacesArgs(object):
                 },
                 "mtu": {"type": "int"},
                 "name": {"required": True, "type": "str"},
+                "vlan_tagging": {"type": "bool"},
                 "speed": {"type": "str"},
                 "units": {
                     "elements": "dict",
                     "options": {
                         "name": {"type": "int"},
                         "description": {"type": "str"},
+                        "vlan_id": {"type": "int"},
                     },
                     "type": "list",
                 },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -40,6 +40,7 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
                 },
                 "name": {"required": True, "type": "str"},
                 "unit": {"type": "int", "default": 0},
+                "description": {"type": "str"},
                 "mtu": {"type": "int"},
                 "vlan_id": {"type": "int"},
                 "vlan_tagging": {"type": "bool"},

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -24,12 +24,18 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
             "options": {
                 "ipv4": {
                     "elements": "dict",
-                    "options": {"address": {"type": "str"}},
+                    "options": {
+                        "address": {"type": "str"},
+                        "preferred": {"type": "bool"},
+                    },
                     "type": "list",
                 },
                 "ipv6": {
                     "elements": "dict",
-                    "options": {"address": {"type": "str"}},
+                    "options": {
+                        "address": {"type": "str"},
+                        "preferred": {"type": "bool"},
+                    },
                     "type": "list",
                 },
                 "name": {"required": True, "type": "str"},

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -41,6 +41,8 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
                 "name": {"required": True, "type": "str"},
                 "unit": {"type": "int", "default": 0},
                 "mtu": {"type": "int"},
+                "vlan_id": {"type": "int"},
+                "vlan_tagging": {"type": "bool"},
             },
             "type": "list",
         },

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
@@ -261,18 +261,19 @@ class Acl_interfaces(ConfigBase):
                 inet_node = build_child_xml_node(family_node, inet_family)
                 if acl_filter.get("acls"):
                     filter_node = build_child_xml_node(inet_node, "filter")
+                    singular = config.get("filter_binding", "list") == "singular"
                     for acl in acl_filter["acls"]:
                         acl_node = None
                         if acl["direction"] == "in":
                             acl_node = build_child_xml_node(
                                 filter_node,
-                                "input-list",
+                                "input" if singular else "input-list",
                                 acl["name"],
                             )
                         else:
                             acl_node = build_child_xml_node(
                                 filter_node,
-                                "output-list",
+                                "output" if singular else "output-list",
                                 acl["name"],
                             )
                         if delete:

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
@@ -175,10 +175,19 @@ class Acl_interfaces(ConfigBase):
         return tostring(root)
 
     def _get_common_xml_node(self, name):
+        interface_name, unit_name = self._split_interface_name(name)
         root_node = build_root_xml_node("interface")
-        build_child_xml_node(root_node, "name", name)
+        build_child_xml_node(root_node, "name", interface_name)
         intf_unit_node = build_child_xml_node(root_node, "unit")
+        build_child_xml_node(intf_unit_node, "name", unit_name)
         return root_node, intf_unit_node
+
+    def _split_interface_name(self, name):
+        if "." in name:
+            interface_name, unit_name = name.rsplit(".", 1)
+            if unit_name.isdigit():
+                return interface_name, unit_name
+        return name, "0"
 
     def _state_replaced(self, want, have):
         """The command generator when state is replaced
@@ -232,7 +241,6 @@ class Acl_interfaces(ConfigBase):
 
         for config in want:
             root_node, unit_node = self._get_common_xml_node(config["name"])
-            build_child_xml_node(unit_node, "name", "0")
             family_node = build_child_xml_node(unit_node, "family")
             for acl_filter in config["access_groups"]:
                 inet_family = "inet"

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/acl_interfaces/acl_interfaces.py
@@ -241,6 +241,18 @@ class Acl_interfaces(ConfigBase):
 
         for config in want:
             root_node, unit_node = self._get_common_xml_node(config["name"])
+            if config.get("vlan_tagging"):
+                if delete:
+                    build_child_xml_node(root_node, "vlan-tagging", None, delete)
+                else:
+                    build_child_xml_node(root_node, "vlan-tagging")
+            if config.get("vlan_id") is not None:
+                build_child_xml_node(
+                    unit_node,
+                    "vlan-id",
+                    None if delete else str(config["vlan_id"]),
+                    delete,
+                )
             family_node = build_child_xml_node(unit_node, "family")
             for acl_filter in config["access_groups"]:
                 inet_family = "inet"

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
@@ -230,16 +230,18 @@ class Interfaces(ConfigBase):
             if config.get("enabled") is not None:
                 build_child_xml_node(intf, "enable" if config.get("enabled") else "disable")
 
+            if config.get("vlan_tagging"):
+                build_child_xml_node(intf, "vlan-tagging")
+
             if config.get("units"):
                 units = config.get("units")
                 for unit in units:
                     unit_node = build_child_xml_node(intf, "unit")
                     build_child_xml_node(unit_node, "name", str(unit["name"]))
-                    build_child_xml_node(
-                        unit_node,
-                        "description",
-                        unit["description"],
-                    )
+                    if unit.get("description"):
+                        build_child_xml_node(unit_node, "description", unit["description"])
+                    if unit.get("vlan_id") is not None:
+                        build_child_xml_node(unit_node, "vlan-id", str(unit["vlan_id"]))
 
             holdtime = config.get("hold_time")
             if holdtime:
@@ -330,6 +332,14 @@ class Interfaces(ConfigBase):
                         {"delete": "delete"},
                     )
 
+                if have_cfg.get("vlan_tagging"):
+                    build_child_xml_node(
+                        intf,
+                        "vlan-tagging",
+                        None,
+                        {"delete": "delete"},
+                    )
+
                 logical_cfg = have_cfg if have_cfg else config
                 if logical_cfg.get("units"):
                     units = logical_cfg.get("units")
@@ -340,12 +350,20 @@ class Interfaces(ConfigBase):
                             "name",
                             str(unit["name"]),
                         )
-                        build_child_xml_node(
-                            unit_node,
-                            "description",
-                            None,
-                            {"delete": "delete"},
-                        )
+                        if unit.get("description") is not None:
+                            build_child_xml_node(
+                                unit_node,
+                                "description",
+                                None,
+                                {"delete": "delete"},
+                            )
+                        if unit.get("vlan_id") is not None:
+                            build_child_xml_node(
+                                unit_node,
+                                "vlan-id",
+                                None,
+                                {"delete": "delete"},
+                            )
 
                 if have_cfg.get("hold_time"):
                     holdtime_ele = build_child_xml_node(intf, "hold-time")

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
@@ -218,6 +218,8 @@ class L3_interfaces(ConfigBase):
             if config.get("vlan_tagging"):
                 build_child_xml_node(root_node, "vlan-tagging")
             build_child_xml_node(unit_node, "name", str(config["unit"]))
+            if config.get("description"):
+                build_child_xml_node(unit_node, "description", config["description"])
             if config.get("vlan_id") is not None:
                 build_child_xml_node(unit_node, "vlan-id", str(config["vlan_id"]))
             if config.get("ipv4"):
@@ -267,6 +269,13 @@ class L3_interfaces(ConfigBase):
             family = build_child_xml_node(unit_node, "family")
             intf = next((intf for intf in have if intf["name"] == config["name"]), None)
             if intf:
+                if "description" in intf:
+                    build_child_xml_node(
+                        unit_node,
+                        "description",
+                        None,
+                        {"delete": "delete"},
+                    )
                 if any(key in intf for key in ("ipv4", "mtu")):
                     ipv4 = build_child_xml_node(family, "inet")
                     self._delete_ipv4_config(intf, ipv4)

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
@@ -243,6 +243,8 @@ class L3_interfaces(ConfigBase):
             else:
                 ip_addresses = build_child_xml_node(ip_protocol, "address")
                 build_child_xml_node(ip_addresses, "name", ip_addr["address"])
+                if ip_addr.get("preferred"):
+                    build_child_xml_node(ip_addresses, "preferred")
 
     def _state_deleted(self, want, have):
         """Generate XML configuration to remove the current configuration of the provided objects.

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
@@ -215,7 +215,11 @@ class L3_interfaces(ConfigBase):
         intf_xml = []
         for config in want:
             root_node, unit_node = self._get_common_xml_node(config["name"])
+            if config.get("vlan_tagging"):
+                build_child_xml_node(root_node, "vlan-tagging")
             build_child_xml_node(unit_node, "name", str(config["unit"]))
+            if config.get("vlan_id") is not None:
+                build_child_xml_node(unit_node, "vlan-id", str(config["vlan_id"]))
             if config.get("ipv4"):
                 self.build_ipaddr_et(config, unit_node)
             if config.get("ipv6"):
@@ -270,6 +274,21 @@ class L3_interfaces(ConfigBase):
                 if any(key in intf for key in ("ipv6", "mtu")):
                     ipv6 = build_child_xml_node(family, "inet6")
                     self._delete_ipv6_config(intf, ipv6)
+
+                if intf.get("vlan_id") is not None:
+                    build_child_xml_node(
+                        unit_node,
+                        "vlan-id",
+                        None,
+                        {"delete": "delete"},
+                    )
+                if intf.get("vlan_tagging"):
+                    build_child_xml_node(
+                        root_node,
+                        "vlan-tagging",
+                        None,
+                        {"delete": "delete"},
+                    )
 
                 intf_xml.append(root_node)
 

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/acl_interfaces/acl_interfaces.py
@@ -169,7 +169,13 @@ class Acl_interfacesFacts(object):
                                     },
                                 )
                 if access_groups["acls"]:
-                    config["name"] = conf["interface"]["name"]
+                    interface_name = conf["interface"]["name"]
+                    unit_name = conf["interface"]["unit"].get("name", "0")
+                    config["name"] = (
+                        "{0}.{1}".format(interface_name, unit_name)
+                        if str(unit_name) != "0"
+                        else interface_name
+                    )
                     config["access_groups"].append(access_groups)
 
         return utils.remove_empties(config)

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/acl_interfaces/acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/acl_interfaces/acl_interfaces.py
@@ -176,6 +176,10 @@ class Acl_interfacesFacts(object):
                         if str(unit_name) != "0"
                         else interface_name
                     )
+                    if "vlan-tagging" in conf["interface"]:
+                        config["vlan_tagging"] = True
+                    if "vlan-id" in conf["interface"]["unit"]:
+                        config["vlan_id"] = int(conf["interface"]["unit"]["vlan-id"])
                     config["access_groups"].append(access_groups)
 
         return utils.remove_empties(config)

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/interfaces/interfaces.py
@@ -155,6 +155,8 @@ class InterfacesFacts(object):
             config["enabled"] = False
         else:
             config["enabled"] = True
+        vlan_tagging = utils.get_xml_conf_arg(conf, "vlan-tagging", data="tag")
+        config["vlan_tagging"] = bool(vlan_tagging)
         cfg = self._get_xml_dict(conf)
         unit_cfg = cfg.get("interface")
         if "unit" in unit_cfg.keys():
@@ -162,15 +164,21 @@ class InterfacesFacts(object):
             unit_lst = []
             unit_dict = {}
             if isinstance(units, dict):
-                if "description" in units.keys():
+                if "description" in units.keys() or "vlan-id" in units.keys():
                     unit_dict["name"] = units["name"]
-                    unit_dict["description"] = units["description"]
+                    if "description" in units.keys():
+                        unit_dict["description"] = units["description"]
+                    if "vlan-id" in units.keys():
+                        unit_dict["vlan_id"] = int(units["vlan-id"])
                     unit_lst.append(unit_dict)
             else:
                 for unit in units:
-                    if "description" in unit.keys():
+                    if "description" in unit.keys() or "vlan-id" in unit.keys():
                         unit_dict["name"] = unit["name"]
-                        unit_dict["description"] = unit["description"]
+                        if "description" in unit.keys():
+                            unit_dict["description"] = unit["description"]
+                        if "vlan-id" in unit.keys():
+                            unit_dict["vlan_id"] = int(unit["vlan-id"])
                         unit_lst.append(unit_dict)
                         unit_dict = {}
             config["units"] = unit_lst

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
@@ -139,6 +139,8 @@ class L3_interfacesFacts(object):
         ipv6 = []
         if "vlan-tagging" in int_dict:
             interface["vlan_tagging"] = True
+        if "description" in unit:
+            interface["description"] = unit["description"]
         if "vlan-id" in unit:
             interface["vlan_id"] = int(unit["vlan-id"])
         if "family" in unit.keys():

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
@@ -144,15 +144,10 @@ class L3_interfacesFacts(object):
                 inet = unit["family"].get("inet")
                 if inet is not None and "address" in inet.keys():
                     if isinstance(inet["address"], dict):
-                        for key, value in inet["address"].items():
-                            addr = {}
-                            addr["address"] = value
-                            ipv4.append(addr)
+                        ipv4.append(self._render_ip_address(inet["address"]))
                     else:
                         for ip in inet["address"]:
-                            addr = {}
-                            addr["address"] = ip["name"]
-                            ipv4.append(addr)
+                            ipv4.append(self._render_ip_address(ip))
             if "inet" in unit["family"]:
                 interface["name"] = int_dict["name"]
                 interface["unit"] = unit["name"]
@@ -177,12 +172,17 @@ class L3_interfacesFacts(object):
                     addresses = inet6.get("address")
                     if addresses:
                         if isinstance(addresses, dict):
-                            for value in addresses.values():
-                                ipv6.append({"address": value})
+                            ipv6.append(self._render_ip_address(addresses))
                         else:
                             for ip in addresses:
-                                ipv6.append({"address": ip["name"]})
+                                ipv6.append(self._render_ip_address(ip))
 
             interface["ipv4"] = ipv4
             interface["ipv6"] = ipv6
         return utils.remove_empties(interface)
+
+    def _render_ip_address(self, address_cfg):
+        ip_address = {"address": address_cfg.get("name")}
+        if "preferred" in address_cfg:
+            ip_address["preferred"] = True
+        return ip_address

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
@@ -137,6 +137,10 @@ class L3_interfacesFacts(object):
         interface = {}
         ipv4 = []
         ipv6 = []
+        if "vlan-tagging" in int_dict:
+            interface["vlan_tagging"] = True
+        if "vlan-id" in unit:
+            interface["vlan_id"] = int(unit["vlan-id"])
         if "family" in unit.keys():
             if "inet" in unit["family"].keys():
                 interface["name"] = int_dict["name"]

--- a/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
@@ -66,6 +66,14 @@ options:
         description:
         - VLAN ID for a tagged logical interface.
         type: int
+      filter_binding:
+        description:
+        - Controls the Junos XML tags used to bind filters to the interface.
+        - C(list) uses C(input-list)/C(output-list), supported on standard Junos.
+        - C(singular) uses C(input)/C(output), required on Junos EVO.
+        type: str
+        choices: [list, singular]
+        default: list
       access_groups:
         type: list
         elements: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
@@ -55,7 +55,8 @@ options:
     suboptions:
       name:
         description:
-        - Name/Identifier for the interface.
+        - Name/Identifier for the interface. Use dotted notation for a logical
+          interface, for example C(xe-0/0/9.10) or C(irb.10).
         type: str
       access_groups:
         type: list

--- a/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_acl_interfaces.py
@@ -58,6 +58,14 @@ options:
         - Name/Identifier for the interface. Use dotted notation for a logical
           interface, for example C(xe-0/0/9.10) or C(irb.10).
         type: str
+      vlan_tagging:
+        description:
+        - Enable VLAN tagging on the interface.
+        type: bool
+      vlan_id:
+        description:
+        - VLAN ID for a tagged logical interface.
+        type: int
       access_groups:
         type: list
         elements: dict

--- a/ansible_collections/juniper/device/plugins/modules/junos_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_interfaces.py
@@ -70,6 +70,10 @@ options:
         - Set the value to C(true) to administratively enabled the interface or C(false)
           to disable it.
         type: bool
+      vlan_tagging:
+        description:
+        - Enable VLAN tagging on the interface.
+        type: bool
       hold_time:
         description:
         - The hold time for given interface name.
@@ -105,6 +109,9 @@ options:
           description:
             description: Specify logical interface description.
             type: str
+          vlan_id:
+            description: Specify VLAN ID for the logical interface.
+            type: int
   running_config:
     description:
     - This option is used only with state I(parsed).

--- a/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
@@ -64,6 +64,14 @@ options:
         - Logical interface number. Value of C(unit) should be of type integer
         default: 0
         type: int
+      vlan_id:
+        description:
+        - VLAN ID for a tagged logical interface.
+        type: int
+      vlan_tagging:
+        description:
+        - Enable VLAN tagging on the physical interface.
+        type: bool
       mtu:
         description:
         - Protocol family maximum transmission unit.

--- a/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
@@ -81,6 +81,10 @@ options:
             description:
             - IPv4 address to be set for the specific interface
             type: str
+          preferred:
+            description:
+            - Mark this address as preferred on the interface.
+            type: bool
       ipv6:
         description:
         - IPv6 addresses to be set for the Layer 3 logical interface mentioned in
@@ -94,6 +98,10 @@ options:
             description:
             - IPv6 address to be set for the specific interface
             type: str
+          preferred:
+            description:
+            - Mark this address as preferred on the interface.
+            type: bool
   running_config:
     description:
     - This option is used only with state I(parsed).

--- a/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_l3_interfaces.py
@@ -64,6 +64,10 @@ options:
         - Logical interface number. Value of C(unit) should be of type integer
         default: 0
         type: int
+      description:
+        description:
+        - Description for the logical interface.
+        type: str
       vlan_id:
         description:
         - VLAN ID for a tagged logical interface.

--- a/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_acl_interfaces_module.rst
+++ b/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_acl_interfaces_module.rst
@@ -202,6 +202,28 @@ Parameters
                         <div>VLAN ID for a tagged logical interface.</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>filter_binding</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>list</b>&nbsp;&larr;</div></li>
+                                    <li>singular</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Controls the Junos XML tags used to bind filters to the interface.</div>
+                        <div>C(list) uses C(input-list)/C(output-list), supported on standard Junos.</div>
+                        <div>C(singular) uses C(input)/C(output), required on Junos EVO.</div>
+                </td>
+            </tr>
 
             <tr>
                 <td colspan="4">

--- a/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_acl_interfaces_module.rst
+++ b/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_acl_interfaces_module.rst
@@ -167,7 +167,39 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Name/Identifier for the interface.</div>
+                        <div>Name/Identifier for the interface. Use dotted notation for a logical interface, for example <code>xe-0/0/9.10</code> or <code>irb.10</code>.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_tagging</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Enable VLAN tagging on the interface.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>VLAN ID for a tagged logical interface.</div>
                 </td>
             </tr>
 

--- a/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_interfaces_module.rst
+++ b/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_interfaces_module.rst
@@ -117,6 +117,22 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_tagging</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Enable VLAN tagging on the interface.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>hold_time</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -263,6 +279,23 @@ Parameters
                 </td>
                 <td>
                         <div>Specify interface unit number.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Specify VLAN ID for the logical interface.</div>
                 </td>
             </tr>
 

--- a/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_l3_interfaces_module.rst
+++ b/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_l3_interfaces_module.rst
@@ -175,6 +175,38 @@ Parameters
                         <div>Logical interface number. Value of <code>unit</code> should be of type integer</div>
                 </td>
             </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>VLAN ID for a tagged logical interface.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vlan_tagging</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Enable VLAN tagging on the physical interface.</div>
+                </td>
+            </tr>
 
             <tr>
                 <td colspan="3">

--- a/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_l3_interfaces_module.rst
+++ b/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_l3_interfaces_module.rst
@@ -59,6 +59,22 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                                        <b>description</b>
+                                        <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                                        <div style="font-size: small">
+                                            <span style="color: purple">string</span>
+                                        </div>
+                                    </td>
+                                    <td>
+                                    </td>
+                                    <td>
+                                            <div>Description for the logical interface.</div>
+                                    </td>
+                                </tr>
+                                <tr>
+                                        <td class="elbow-placeholder"></td>
+                                    <td colspan="2">
+                                        <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>ipv4</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/deleted.yaml
+++ b/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/deleted.yaml
@@ -14,6 +14,7 @@
       ansible.builtin.set_fact:
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:

--- a/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/gathered.yaml
+++ b/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/gathered.yaml
@@ -10,6 +10,7 @@
       ansible.builtin.set_fact:
         expected_gathered_config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:
@@ -22,6 +23,7 @@
       junipernetworks.junos.junos_acl_interfaces:
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:

--- a/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/merged.yaml
+++ b/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/merged.yaml
@@ -11,6 +11,7 @@
       ansible.builtin.set_fact:
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:
@@ -23,6 +24,7 @@
       junipernetworks.junos.junos_acl_interfaces: &merged
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:

--- a/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/overridden.yaml
+++ b/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/overridden.yaml
@@ -14,6 +14,7 @@
       ansible.builtin.set_fact:
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:
@@ -24,6 +25,7 @@
       junipernetworks.junos.junos_acl_interfaces:
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:

--- a/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/replaced.yaml
+++ b/ansible_collections/junipernetworks/junos/tests/integration/targets/junos_acl_interfaces/tests/netconf/replaced.yaml
@@ -14,6 +14,7 @@
       ansible.builtin.set_fact:
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:
@@ -28,6 +29,7 @@
       junipernetworks.junos.junos_acl_interfaces:
         config:
           - name: ge-1/0/0
+            filter_binding: list
             access_groups:
               - afi: ipv4
                 acls:

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
@@ -111,27 +111,6 @@ class TestJunosInterfacesModule(TestJunosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
-    def test_junos_interfaces_vlan_tagging_and_unit_vlan_id(self):
-        set_module_args(
-            dict(
-                config=[
-                    dict(
-                        name="xe-0/0/4",
-                        vlan_tagging=True,
-                        units=[dict(name=10, vlan_id=100)],
-                    ),
-                ],
-                state="rendered",
-            ),
-        )
-        commands = [
-            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
-            "<nc:interface><nc:name>xe-0/0/4</nc:name><nc:vlan-tagging/>"
-            "<nc:unit><nc:name>10</nc:name><nc:vlan-id>100</nc:vlan-id>"
-            "</nc:unit></nc:interface></nc:interfaces>",
-        ]
-        self.execute_module(changed=False, commands=commands)
-
     def test_junos_interfaces_merged_idempotent(self):
         self.get_config.return_value = load_fixture(
             "junos_interfaces_config.xml",

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
@@ -111,6 +111,27 @@ class TestJunosInterfacesModule(TestJunosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
+    def test_junos_interfaces_vlan_tagging_and_unit_vlan_id(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="xe-0/0/4",
+                        vlan_tagging=True,
+                        units=[dict(name=10, vlan_id=100)],
+                    ),
+                ],
+                state="rendered",
+            ),
+        )
+        commands = [
+            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            "<nc:interface><nc:name>xe-0/0/4</nc:name><nc:vlan-tagging/>"
+            "<nc:unit><nc:name>10</nc:name><nc:vlan-id>100</nc:vlan-id>"
+            "</nc:unit></nc:interface></nc:interfaces>",
+        ]
+        self.execute_module(changed=False, commands=commands)
+
     def test_junos_interfaces_merged_idempotent(self):
         self.get_config.return_value = load_fixture(
             "junos_interfaces_config.xml",

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l3_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l3_interfaces.py
@@ -113,52 +113,6 @@ class TestJunosL3InterfacesModule(TestJunosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
-    def test_junos_l3_interfaces_logical_unit_description(self):
-        set_module_args(
-            dict(
-                config=[
-                    dict(
-                        name="xe-0/0/14",
-                        unit=30,
-                        description="Customer broadband logical unit",
-                    ),
-                ],
-                state="rendered",
-            ),
-        )
-        commands = [
-            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
-            "<nc:interface><nc:name>xe-0/0/14</nc:name><nc:unit>"
-            "<nc:name>30</nc:name>"
-            "<nc:description>Customer broadband logical unit</nc:description>"
-            "</nc:unit></nc:interface></nc:interfaces>",
-        ]
-        self.execute_module(changed=False, commands=commands)
-
-    def test_junos_l3_interfaces_preferred_addresses(self):
-        set_module_args(
-            dict(
-                config=[
-                    dict(
-                        name="ge-0/0/1",
-                        ipv4=[dict(address="192.0.2.1/24", preferred=True)],
-                        ipv6=[dict(address="2001:db8::1/64", preferred=True)],
-                    ),
-                ],
-                state="rendered",
-            ),
-        )
-        commands = [
-            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
-            "<nc:interface><nc:name>ge-0/0/1</nc:name><nc:unit><nc:name>0</nc:name>"
-            "<nc:family><nc:inet><nc:address><nc:name>192.0.2.1/24</nc:name>"
-            "<nc:preferred/></nc:address></nc:inet></nc:family>"
-            "<nc:family><nc:inet6><nc:address><nc:name>2001:db8::1/64</nc:name>"
-            "<nc:preferred/></nc:address></nc:inet6></nc:family>"
-            "</nc:unit></nc:interface></nc:interfaces>",
-        ]
-        self.execute_module(changed=False, commands=commands)
-
     def test_junos_l3_interfaces_merged_idempotent(self):
         self.get_config.return_value = load_fixture(
             "junos_interfaces_config.xml",

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l3_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l3_interfaces.py
@@ -113,6 +113,52 @@ class TestJunosL3InterfacesModule(TestJunosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
+    def test_junos_l3_interfaces_logical_unit_description(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="xe-0/0/14",
+                        unit=30,
+                        description="Customer broadband logical unit",
+                    ),
+                ],
+                state="rendered",
+            ),
+        )
+        commands = [
+            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            "<nc:interface><nc:name>xe-0/0/14</nc:name><nc:unit>"
+            "<nc:name>30</nc:name>"
+            "<nc:description>Customer broadband logical unit</nc:description>"
+            "</nc:unit></nc:interface></nc:interfaces>",
+        ]
+        self.execute_module(changed=False, commands=commands)
+
+    def test_junos_l3_interfaces_preferred_addresses(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="ge-0/0/1",
+                        ipv4=[dict(address="192.0.2.1/24", preferred=True)],
+                        ipv6=[dict(address="2001:db8::1/64", preferred=True)],
+                    ),
+                ],
+                state="rendered",
+            ),
+        )
+        commands = [
+            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            "<nc:interface><nc:name>ge-0/0/1</nc:name><nc:unit><nc:name>0</nc:name>"
+            "<nc:family><nc:inet><nc:address><nc:name>192.0.2.1/24</nc:name>"
+            "<nc:preferred/></nc:address></nc:inet></nc:family>"
+            "<nc:family><nc:inet6><nc:address><nc:name>2001:db8::1/64</nc:name>"
+            "<nc:preferred/></nc:address></nc:inet6></nc:family>"
+            "</nc:unit></nc:interface></nc:interfaces>",
+        ]
+        self.execute_module(changed=False, commands=commands)
+
     def test_junos_l3_interfaces_merged_idempotent(self):
         self.get_config.return_value = load_fixture(
             "junos_interfaces_config.xml",


### PR DESCRIPTION
## Description

Fixed intergration testing 

Closes #<!-- issue number -->

---

## Collection Namespace

<!-- Identify which collection(s) this PR affects -->

- **Collection namespace:** <!-- e.g. juniper.device or junipernetworks.junos -->
- **Collection version (bumped to):** <!-- e.g. 3.2.0 — update galaxy.yml if applicable -->
- **Module(s) / plugin(s) changed:** <!-- e.g. juniper.device.config, junipernetworks.junos.junos_command -->

---

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature / new module or plugin (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing module or plugin behaviour)
- [ ] Breaking change (fix or feature that would cause existing playbooks / roles to behave differently)
- [ ] Task / Chore (refactor, dependency update, CI, docs, etc.)

---

## Fix Details

<!-- Describe the root cause and what was changed to fix it. Be specific. -->

### Root Cause

<!-- What was the underlying problem? -->

### Solution

<!-- How does this PR address it? List the key changes. -->

- 
- 
- 

---

## Versions Tested

<!-- Fill in the versions you tested against. Add or remove rows as needed. -->

| Item | Version |
|------|---------|
| Collection namespace & version | <!-- e.g. juniper.device 3.2.0 --> |
| Ansible / ansible-core | <!-- e.g. ansible-core 2.15.3 --> |
| Python | <!-- e.g. 3.10.12 --> |
| OS | <!-- e.g. Ubuntu 22.04 --> |
| Junos version | <!-- e.g. 22.2R1.9 --> |
| Junos platform | <!-- e.g. MX480, vMX, QFX5100 --> |
| junos-eznc | <!-- e.g. 2.7.1 --> |
| ncclient | <!-- e.g. 0.6.15 --> |

---

## Sanity Test Results

<!-- Run sanity tests and paste the summary output below. -->

- [ ] Sanity tests pass with no new errors

```bash
ansible-test sanity
```

<details>
<summary>Sanity test output</summary>

```
<paste sanity test output here>
```

</details>

---

## Unit Test Results

<!-- Run unit tests and paste the summary output below. -->

- [ ] New or updated unit tests added under `tests/unit/`
- [ ] All unit tests pass locally

```bash
python3.12 -m pytest
```

<details>
<summary>Unit test output</summary>

```
<paste unit test output here>
```

</details>

- [ ] Code coverage has not decreased

---

## Integration Test Results

<!-- Run integration tests against a real or virtual Junos device and paste the summary. -->

- [ ] Integration tests reviewed for impact
- [ ] Affected integration tests pass (requires a live Junos device or vMX)

```bash
ansible-test network-integration --python 3.12 --inventory /root/pyez_ansible_release_validation1/ansible-junos-stdlib/ansible_collections/juniper/device/tests/integration/inventory.networking
```

<details>
<summary>Integration test output</summary>

```
<paste integration test output here>
```

</details>

---

## Checklist

### Code Quality

- [ ] Code follows the project's style guidelines
- [ ] `ansible-lint` passes with no new errors

```bash
ansible-lint
```

- [ ] `flake8` / `ruff` reports no new errors (for Python files)

```bash
flake8 plugins/
# or
ruff check plugins/
```

### Documentation

- [ ] Module documentation (DOCUMENTATION, EXAMPLES, RETURN blocks) updated if parameters changed
- [ ] `CHANGELOG.rst` / `changelogs/fragments/` entry added
- [ ] `galaxy.yml` version bumped if releasing

### General

- [ ] No hardcoded credentials, IP addresses, or sensitive data introduced
- [ ] `requirements.txt` updated if new Python packages are required
- [ ] Backward-compatible: existing playbooks will not break

---

## Additional Notes

<!-- Anything else reviewers should know: deployment considerations, follow-up tasks, known limitations, related PRs, etc. -->
