### PR TITLE
Enable & Disable logical interface unit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,11 +145,14 @@ jobs:
           # 2. Install ncclient (Required to fix the 'new_ele' bug in netcommon)
           python -m pip install ncclient
 
-          # 3. Install juniper.device under the Junos collection's local search root.
-          # tox runs from that directory with ANSIBLE_COLLECTIONS_PATH=., so installing
-          # to the default user path would allow a stale collection to be selected.
+          # 3. Install the local juniper.device so it satisfies the
+          # "juniper.device: >=2.0.0" dependency instead of the stale Galaxy-published
+          # collection. Install it both under the Junos collection's local search root
+          # (tox runs from there with ANSIBLE_COLLECTIONS_PATH=.) and the default path
+          # (used by ade dependency resolution), so the local code always wins.
           ansible-galaxy collection install ansible_collections/juniper/device/ --force \
             -p ansible_collections/junipernetworks/junos
+          ansible-galaxy collection install ansible_collections/juniper/device/ --force
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: "Check for tox-ansible.ini file, else add default"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,8 +70,6 @@ jobs:
             ansible: "2.19"
           - python: "3.12"
             ansible: "2.19"
-          - python: "3.13"
-            ansible: "2.19"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -100,7 +98,7 @@ jobs:
       - name: Run tox sanity tests
         if: matrix.collection == 'juniper/device'
         working-directory: ansible_collections/${{ matrix.collection }}
-        run: ansible-test sanity --python 3.13
+        run: ansible-test sanity --python 3.12
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Run tox sanity tests
@@ -124,8 +122,6 @@ jobs:
           - python: "3.11"
             ansible: "2.19"
           - python: "3.12"
-            ansible: "2.19"
-          - python: "3.13"
             ansible: "2.19"
     steps:
       - uses: actions/checkout@v4
@@ -185,8 +181,6 @@ jobs:
             python_version: "3.11"
           - ansible_version: "stable-2.19"
             python_version: "3.12"
-          - ansible_version: "stable-2.19"
-            python_version: "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,9 +157,11 @@ jobs:
           # 2. Install ncclient (Required to fix the 'new_ele' bug in netcommon)
           python -m pip install ncclient
 
-          # 3. Install juniper.device directly from the local folder
-          # This links the local code without creating a tarball
-          ansible-galaxy collection install ansible_collections/juniper/device/ --force
+          # 3. Install juniper.device under the Junos collection's local search root.
+          # tox runs from that directory with ANSIBLE_COLLECTIONS_PATH=., so installing
+          # to the default user path would allow a stale collection to be selected.
+          ansible-galaxy collection install ansible_collections/juniper/device/ --force \
+            -p ansible_collections/junipernetworks/junos
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: "Check for tox-ansible.ini file, else add default"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        collection: [juniper/device, junipernetworks/junos]
+        collection: [juniper/device]
         include:
           - python: "3.10"
             ansible: "2.17"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,16 +67,10 @@ jobs:
           - python: "3.10"
             ansible: "2.17"
           - python: "3.11"
-            ansible: "2.17"
-          - python: "3.11"
-            ansible: "2.18"
-          - python: "3.11"
             ansible: "2.19"
           - python: "3.12"
-            ansible: "2.17"
-          - python: "3.12"
-            ansible: "2.18"
-          - python: "3.12"
+            ansible: "2.19"
+          - python: "3.13"
             ansible: "2.19"
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +100,7 @@ jobs:
       - name: Run tox sanity tests
         if: matrix.collection == 'juniper/device'
         working-directory: ansible_collections/${{ matrix.collection }}
-        run: ansible-test sanity --python 3.12
+        run: ansible-test sanity --python 3.13
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Run tox sanity tests
@@ -128,16 +122,10 @@ jobs:
           - python: "3.10"
             ansible: "2.17"
           - python: "3.11"
-            ansible: "2.17"
-          - python: "3.11"
-            ansible: "2.18"
-          - python: "3.11"
             ansible: "2.19"
           - python: "3.12"
-            ansible: "2.17"
-          - python: "3.12"
-            ansible: "2.18"
-          - python: "3.12"
+            ansible: "2.19"
+          - python: "3.13"
             ansible: "2.19"
     steps:
       - uses: actions/checkout@v4
@@ -188,19 +176,13 @@ jobs:
       matrix:
         collection: [juniper/device, junipernetworks/junos]
         include:
-          - ansible_version: "stable-2.16"
-            python_version: "3.11"
           - ansible_version: "stable-2.17"
-            python_version: "3.11"
-          - ansible_version: "stable-2.18"
-            python_version: "3.11"
+            python_version: "3.10"
           - ansible_version: "stable-2.19"
             python_version: "3.11"
-          - ansible_version: "stable-2.20"
+          - ansible_version: "stable-2.19"
             python_version: "3.12"
-          - ansible_version: "milestone"
-            python_version: "3.12"
-          - ansible_version: "devel"
+          - ansible_version: "stable-2.19"
             python_version: "3.13"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -121,8 +121,6 @@ jobs:
             ansible: "2.17"
           - python: "3.11"
             ansible: "2.19"
-          - python: "3.12"
-            ansible: "2.19"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -179,8 +177,6 @@ jobs:
             python_version: "3.10"
           - ansible_version: "stable-2.19"
             python_version: "3.11"
-          - ansible_version: "stable-2.19"
-            python_version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,20 +151,17 @@ jobs:
       - name: Install Dependencies
         if: matrix.collection == 'junipernetworks/junos'
         run: |
-          # 1. Install ansible.netcommon
-          ansible-galaxy collection install ansible.netcommon
+          # Install cross-collection deps into the ABSOLUTE workspace tree so the
+          # tox step's ANSIBLE_COLLECTIONS_PATH resolves every collection via an
+          # absolute path. ansible-core >=2.19 raises "relative resource paths
+          # not supported" when reading collection source through a relative path.
+          # juniper.device and junipernetworks.junos already live under the
+          # workspace (checked-out source), so only netcommon/utils are added here.
+          ansible-galaxy collection install ansible.netcommon ansible.utils \
+            -p "${{ github.workspace }}" --force
 
-          # 2. Install ncclient (Required to fix the 'new_ele' bug in netcommon)
+          # ncclient fixes the 'new_ele' bug in netcommon.
           python -m pip install ncclient
-
-          # 3. Install the local juniper.device so it satisfies the
-          # "juniper.device: >=2.0.0" dependency instead of the stale Galaxy-published
-          # collection. Install it both under the Junos collection's local search root
-          # (tox runs from there with ANSIBLE_COLLECTIONS_PATH=.) and the default path
-          # (used by ade dependency resolution), so the local code always wins.
-          ansible-galaxy collection install ansible_collections/juniper/device/ --force \
-            -p ansible_collections/junipernetworks/junos
-          ansible-galaxy collection install ansible_collections/juniper/device/ --force
       - name: "Install tox-ansible, includes tox"
         run: python -m pip install tox-ansible
       - name: "Check for tox-ansible.ini file, else add default"
@@ -181,6 +178,10 @@ jobs:
           python -m tox --ansible -c tox-ansible.ini -e unit-py${{ matrix.python }}-${{ matrix.ansible }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # ansible-core >=2.19 rejects reading collection source via relative
+          # paths; force the sibling juniper.device to resolve absolutely.
+          ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}"
+          TOX_OVERRIDE: "testenv.passenv=ANSIBLE_COLLECTIONS_PATH"
 
 
   unit-source:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,20 +64,16 @@ jobs:
       matrix:
         collection: [juniper/device, junipernetworks/junos]
         include:
-          - python: "3.10"
-            ansible: "2.17"
-          - python: "3.11"
-            ansible: "2.17"
-          - python: "3.11"
-            ansible: "2.18"
           - python: "3.11"
             ansible: "2.19"
+          - python: "3.11"
+            ansible: "2.20"
+          - python: "3.11"
+            ansible: "2.21"
           - python: "3.12"
-            ansible: "2.17"
-          - python: "3.12"
-            ansible: "2.18"
-          - python: "3.12"
-            ansible: "2.19"
+            ansible: "2.21"
+          - python: "3.13"
+            ansible: "2.21"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -125,20 +121,16 @@ jobs:
       matrix:
         collection: [juniper/device, junipernetworks/junos]
         include:
-          - python: "3.10"
-            ansible: "2.17"
-          - python: "3.11"
-            ansible: "2.17"
-          - python: "3.11"
-            ansible: "2.18"
           - python: "3.11"
             ansible: "2.19"
+          - python: "3.11"
+            ansible: "2.20"
+          - python: "3.11"
+            ansible: "2.21"
           - python: "3.12"
-            ansible: "2.17"
-          - python: "3.12"
-            ansible: "2.18"
-          - python: "3.12"
-            ansible: "2.19"
+            ansible: "2.21"
+          - python: "3.13"
+            ansible: "2.21"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -153,8 +145,9 @@ jobs:
         run: |
           # Install cross-collection deps into the ABSOLUTE workspace tree so the
           # tox step's ANSIBLE_COLLECTIONS_PATH resolves every collection via an
-          # absolute path. ansible-core >=2.19 raises "relative resource paths
-          # not supported" when reading collection source through a relative path.
+          # absolute path. ansible-core's collection loader raises "relative
+          # resource paths not supported" when reading collection source through
+          # a relative path (long-standing invariant, present in 2.17-2.21).
           # juniper.device and junipernetworks.junos already live under the
           # workspace (checked-out source), so only netcommon/utils are added here.
           ansible-galaxy collection install ansible.netcommon ansible.utils \
@@ -178,8 +171,8 @@ jobs:
           python -m tox --ansible -c tox-ansible.ini -e unit-py${{ matrix.python }}-${{ matrix.ansible }}
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          # ansible-core >=2.19 rejects reading collection source via relative
-          # paths; force the sibling juniper.device to resolve absolutely.
+          # ansible-core's collection loader rejects reading source via relative
+          # paths; force every collection to resolve from the absolute workspace.
           ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}"
           TOX_OVERRIDE: "testenv.passenv=ANSIBLE_COLLECTIONS_PATH"
 
@@ -192,18 +185,14 @@ jobs:
       matrix:
         collection: [juniper/device, junipernetworks/junos]
         include:
-          - ansible_version: "stable-2.16"
-            python_version: "3.11"
-          - ansible_version: "stable-2.17"
-            python_version: "3.11"
-          - ansible_version: "stable-2.18"
-            python_version: "3.11"
           - ansible_version: "stable-2.19"
             python_version: "3.11"
           - ansible_version: "stable-2.20"
+            python_version: "3.11"
+          - ansible_version: "stable-2.21"
             python_version: "3.12"
           - ansible_version: "milestone"
-            python_version: "3.12"
+            python_version: "3.13"
           - ansible_version: "devel"
             python_version: "3.13"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,41 +140,27 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python }}"
-      - name: Install Dependencies
+      - name: Install unit-test dependencies
         if: matrix.collection == 'junipernetworks/junos'
         run: |
-          # Install cross-collection deps into the ABSOLUTE workspace tree so the
-          # tox step's ANSIBLE_COLLECTIONS_PATH resolves every collection via an
-          # absolute path. ansible-core's collection loader raises "relative
-          # resource paths not supported" when reading collection source through
-          # a relative path (long-standing invariant, present in 2.17-2.21).
-          # juniper.device and junipernetworks.junos already live under the
-          # workspace (checked-out source), so only netcommon/utils are added here.
+          python -m pip install "ansible-core~=${{ matrix.ansible }}.0" \
+            pytest pytest-ansible pytest-xdist pytest-cov \
+            lxml xmltodict ncclient jxmlease
+          # Install netcommon/utils into the ABSOLUTE workspace so the local
+          # juniper.device (checked-out source with unreleased features) and the
+          # junos collection all resolve from one absolute ANSIBLE_COLLECTIONS_PATH.
           ansible-galaxy collection install ansible.netcommon ansible.utils \
             -p "${{ github.workspace }}" --force
-
-          # ncclient fixes the 'new_ele' bug in netcommon.
-          python -m pip install ncclient
-      - name: "Install tox-ansible, includes tox"
-        run: python -m pip install tox-ansible
-      - name: "Check for tox-ansible.ini file, else add default"
-        uses: ansible/ansible-content-actions/.github/actions/add_tox_ansible@main
-      - name: Copy tox-ansible.ini to collection directory
-        run: |
-          if [ -f tox-ansible.ini ]; then
-            cp tox-ansible.ini ansible_collections/${{ matrix.collection }}/
-          fi
-      - name: Run tox unit tests
+      - name: Run junos unit tests against local collections
         if: matrix.collection == 'junipernetworks/junos'
         working-directory: ansible_collections/${{ matrix.collection }}
-        run: >-
-          python -m tox --ansible -c tox-ansible.ini -e unit-py${{ matrix.python }}-${{ matrix.ansible }}
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          # ansible-core's collection loader rejects reading source via relative
-          # paths; force every collection to resolve from the absolute workspace.
+          # Resolve every collection from the absolute workspace source. This uses
+          # the LOCAL juniper.device (not the stale Galaxy release, which lacks
+          # unreleased features) and avoids ansible-core's long-standing
+          # "relative resource paths not supported" invariant.
           ANSIBLE_COLLECTIONS_PATH: "${{ github.workspace }}"
-          TOX_OVERRIDE: "testenv.passenv=ANSIBLE_COLLECTIONS_PATH"
+        run: python -m pytest --ansible-unit-inject-only ./tests/unit
 
 
   unit-source:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,15 @@ jobs:
           - python: "3.10"
             ansible: "2.17"
           - python: "3.11"
+            ansible: "2.17"
+          - python: "3.11"
+            ansible: "2.18"
+          - python: "3.11"
             ansible: "2.19"
+          - python: "3.12"
+            ansible: "2.17"
+          - python: "3.12"
+            ansible: "2.18"
           - python: "3.12"
             ansible: "2.19"
     steps:
@@ -115,11 +123,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        collection: [juniper/device]
+        collection: [juniper/device, junipernetworks/junos]
         include:
           - python: "3.10"
             ansible: "2.17"
           - python: "3.11"
+            ansible: "2.17"
+          - python: "3.11"
+            ansible: "2.18"
+          - python: "3.11"
+            ansible: "2.19"
+          - python: "3.12"
+            ansible: "2.17"
+          - python: "3.12"
+            ansible: "2.18"
+          - python: "3.12"
             ansible: "2.19"
     steps:
       - uses: actions/checkout@v4
@@ -173,10 +191,20 @@ jobs:
       matrix:
         collection: [juniper/device, junipernetworks/junos]
         include:
+          - ansible_version: "stable-2.16"
+            python_version: "3.11"
           - ansible_version: "stable-2.17"
-            python_version: "3.10"
+            python_version: "3.11"
+          - ansible_version: "stable-2.18"
+            python_version: "3.11"
           - ansible_version: "stable-2.19"
             python_version: "3.11"
+          - ansible_version: "stable-2.20"
+            python_version: "3.12"
+          - ansible_version: "milestone"
+            python_version: "3.12"
+          - ansible_version: "devel"
+            python_version: "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
@@ -449,6 +449,10 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                             "type": "dict",
                         },
                         "name": {"type": "str"},
+                        "apply_groups": {
+                            "elements": "str",
+                            "type": "list",
+                        },
                         "neighbors": {
                             "elements": "dict",
                             "options": {
@@ -722,6 +726,10 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                     "type": "dict",
                                 },
                                 "neighbor_address": {"type": "str"},
+                                "apply_groups": {
+                                    "elements": "str",
+                                    "type": "list",
+                                },
                                 "no_advertise_peer_as": {"type": "bool"},
                                 "no_aggregator_id": {"type": "bool"},
                                 "no_client_reflect": {"type": "bool"},

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
@@ -448,6 +448,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                             },
                             "type": "dict",
                         },
+                        "inactive": {"type": "bool"},
                         "name": {"type": "str"},
                         "apply_groups": {
                             "elements": "str",
@@ -725,6 +726,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                                     },
                                     "type": "dict",
                                 },
+                                "inactive": {"type": "bool"},
                                 "neighbor_address": {"type": "str"},
                                 "apply_groups": {
                                     "elements": "str",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/argspec/interfaces/interfaces.py
@@ -64,6 +64,7 @@ class InterfacesArgs(object):
                     "options": {
                         "name": {"type": "int"},
                         "description": {"type": "str"},
+                        "enabled": {"type": "bool"},
                         "vlan_id": {"type": "int"},
                     },
                     "type": "list",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
@@ -677,6 +677,19 @@ class Bgp_global(ConfigBase):
                     orr.get("igp_primary"),
                 )
 
+        if want.get("local_as"):
+            local_as = want.get("local_as")
+            local_as_node = build_child_xml_node(bgp_root, "local-as")
+            build_child_xml_node(local_as_node, "as-number", local_as["as_num"])
+            if local_as.get("alias"):
+                build_child_xml_node(local_as_node, "alias")
+            if local_as.get("private"):
+                build_child_xml_node(local_as_node, "private")
+            if local_as.get("loops") is not None:
+                build_child_xml_node(local_as_node, "loops", local_as["loops"])
+            if local_as.get("no_prepend_global_as"):
+                build_child_xml_node(local_as_node, "no-prepend-global-as")
+
     def _state_deleted(self, want, have):
         """The command generator when state is deleted
         :rtype: A list

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
@@ -306,6 +306,8 @@ class Bgp_global(ConfigBase):
                 # Generate commands for each group in group list
                 for group in groups:
                     groups_node = build_child_xml_node(bgp_root, "group")
+                    if group.get("inactive"):
+                        groups_node.set("inactive", "inactive")
                     build_child_xml_node(groups_node, "name", group["name"])
                     self._add_apply_groups(groups_node, group)
                     # Parse the boolean value attributes
@@ -339,6 +341,8 @@ class Bgp_global(ConfigBase):
                                 groups_node,
                                 "neighbor",
                             )
+                            if neighbor.get("inactive"):
+                                neighbors_node.set("inactive", "inactive")
                             build_child_xml_node(
                                 neighbors_node,
                                 "name",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
@@ -307,6 +307,7 @@ class Bgp_global(ConfigBase):
                 for group in groups:
                     groups_node = build_child_xml_node(bgp_root, "group")
                     build_child_xml_node(groups_node, "name", group["name"])
+                    self._add_apply_groups(groups_node, group)
                     # Parse the boolean value attributes
                     for item in bool_parser:
                         groups_node = self._add_node(
@@ -343,6 +344,7 @@ class Bgp_global(ConfigBase):
                                 "name",
                                 neighbor["neighbor_address"],
                             )
+                            self._add_apply_groups(neighbors_node, neighbor)
                             # Parse the boolean value attributes
                             for item in bool_parser:
                                 neighbors_node = self._add_node(
@@ -690,6 +692,10 @@ class Bgp_global(ConfigBase):
             if local_as.get("no_prepend_global_as"):
                 build_child_xml_node(local_as_node, "no-prepend-global-as")
 
+    def _add_apply_groups(self, node, config):
+        for apply_group in config.get("apply_groups", []):
+            build_child_xml_node(node, "apply-groups", apply_group)
+
     def _state_deleted(self, want, have):
         """The command generator when state is deleted
         :rtype: A list
@@ -800,6 +806,7 @@ class Bgp_global(ConfigBase):
             "authentication-algorithm",
             "authentication-key",
             "authentication-key-chain",
+            "apply-groups",
             "as-override",
             "bfd-liveness-detection",
             "bgp-error-tolerance",
@@ -866,6 +873,7 @@ class Bgp_global(ConfigBase):
                     delete if set(group.keys()) == set(["name"]) else None,
                 )
                 build_child_xml_node(group_node, "name", group["name"])
+                self._delete_apply_groups(group_node, group)
                 self._delete_requested_attributes(group_node, group, parser)
                 if group.get("neighbors"):
                     for neighbor in group.get("neighbors"):
@@ -882,6 +890,7 @@ class Bgp_global(ConfigBase):
                             "name",
                             neighbor["neighbor_address"],
                         )
+                        self._delete_apply_groups(neighbor_node, neighbor)
                         self._delete_requested_attributes(
                             neighbor_node,
                             neighbor,
@@ -892,11 +901,17 @@ class Bgp_global(ConfigBase):
     def _delete_requested_attributes(self, node, want, parser):
         delete = {"delete": "delete"}
         for attrib in parser:
+            if attrib == "apply-groups":
+                continue
             want_key = attrib.replace("-", "_")
             if attrib == "cluster":
                 want_key = "cluster_id"
             if want_key in want.keys():
                 build_child_xml_node(node, attrib, None, delete)
+
+    def _delete_apply_groups(self, node, config):
+        for apply_group in config.get("apply_groups", []):
+            build_child_xml_node(node, "apply-groups", apply_group, {"delete": "delete"})
 
     def _state_purged(self, want, have):
         """The command generator when state is deleted

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
@@ -697,6 +697,20 @@ class Bgp_global(ConfigBase):
                   of the provided objects
         """
         bgp_xml = []
+        if have is not None and want:
+            want = remove_empties(want)
+            bgp_root = self._render_delete_bgp(want)
+            if bgp_root.getchildren():
+                bgp_xml.append(bgp_root)
+            if want.get("as_number"):
+                build_child_xml_node(
+                    self.routing_options,
+                    "autonomous-system",
+                    None,
+                    {"delete": "delete"},
+                )
+            return bgp_xml
+
         parser = [
             "accept-remote-nexthop",
             "add-path-display-ipv4-address",
@@ -770,6 +784,118 @@ class Bgp_global(ConfigBase):
                 )
             bgp_xml.append(bgp_root)
         return bgp_xml
+
+    def _render_delete_bgp(self, want):
+        delete = {"delete": "delete"}
+        bgp_root = build_root_xml_node("bgp")
+        parser = [
+            "accept-remote-nexthop",
+            "add-path-display-ipv4-address",
+            "advertise-bgp-static",
+            "advertise-external",
+            "advertise-from-main-vpn-tables",
+            "advertise-inactive",
+            "advertise-peer-as",
+            "authentication-algorithm",
+            "authentication-key",
+            "authentication-key-chain",
+            "as-override",
+            "bfd-liveness-detection",
+            "bgp-error-tolerance",
+            "bmp",
+            "cluster",
+            "damping",
+            "description",
+            "disable",
+            "egress-te",
+            "egress-te-sid-stats",
+            "enforce-first-as",
+            "export",
+            "forwarding-context",
+            "graceful-restart",
+            "hold-time",
+            "idle-after-switch-over",
+            "holddown-all-stale-labels",
+            "import",
+            "include-mp-next-hop",
+            "ipsec-sa",
+            "keep",
+            "local-address",
+            "local-as",
+            "local-interface",
+            "local-preference",
+            "log-updown",
+            "metric-out",
+            "mtu-discovery",
+            "multihop",
+            "multipath",
+            "no-advertise-peer-as",
+            "no-aggregator-id",
+            "no-client-reflect",
+            "no-precision-timers",
+            "out-delay",
+            "outbound-route-filter",
+            "passive",
+            "path-selection",
+            "peer-as",
+            "precision-timers",
+            "preference",
+            "remove-private",
+            "rfc6514-compliant-safi129",
+            "route-server-client",
+            "send-addpath-optimization",
+            "snmp-options",
+            "sr-preference-override",
+            "stale-labels-holddown-period",
+            "tcp-aggressive-transmission",
+            "tcp-mss",
+            "traceoptions",
+            "traffic-statistics-labeled-path",
+            "ttl",
+            "unconfigured-peer-graceful-restart",
+            "vpn-apply-export",
+        ]
+        self._delete_requested_attributes(bgp_root, want, parser)
+        if want.get("groups"):
+            for group in want.get("groups"):
+                group_node = build_child_xml_node(
+                    bgp_root,
+                    "group",
+                    None,
+                    delete if set(group.keys()) == set(["name"]) else None,
+                )
+                build_child_xml_node(group_node, "name", group["name"])
+                self._delete_requested_attributes(group_node, group, parser)
+                if group.get("neighbors"):
+                    for neighbor in group.get("neighbors"):
+                        neighbor_node = build_child_xml_node(
+                            group_node,
+                            "neighbor",
+                            None,
+                            delete
+                            if set(neighbor.keys()) == set(["neighbor_address"])
+                            else None,
+                        )
+                        build_child_xml_node(
+                            neighbor_node,
+                            "name",
+                            neighbor["neighbor_address"],
+                        )
+                        self._delete_requested_attributes(
+                            neighbor_node,
+                            neighbor,
+                            parser,
+                        )
+        return bgp_root
+
+    def _delete_requested_attributes(self, node, want, parser):
+        delete = {"delete": "delete"}
+        for attrib in parser:
+            want_key = attrib.replace("-", "_")
+            if attrib == "cluster":
+                want_key = "cluster_id"
+            if want_key in want.keys():
+                build_child_xml_node(node, attrib, None, delete)
 
     def _state_purged(self, want, have):
         """The command generator when state is deleted

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
@@ -193,7 +193,7 @@ class Bgp_global(ConfigBase):
                   the current configuration
         """
         bgp_xml = []
-        bgp_xml.extend(self._state_deleted(want, have))
+        bgp_xml.extend(self._state_deleted({}, have))
         bgp_xml.extend(self._state_merged(want, have))
 
         return bgp_xml
@@ -699,17 +699,18 @@ class Bgp_global(ConfigBase):
         bgp_xml = []
         if have is not None and want:
             want = remove_empties(want)
-            bgp_root = self._render_delete_bgp(want)
-            if bgp_root.getchildren():
-                bgp_xml.append(bgp_root)
-            if want.get("as_number"):
-                build_child_xml_node(
-                    self.routing_options,
-                    "autonomous-system",
-                    None,
-                    {"delete": "delete"},
-                )
-            return bgp_xml
+            if want:
+                bgp_root = self._render_delete_bgp(want)
+                if bgp_root.getchildren():
+                    bgp_xml.append(bgp_root)
+                if want.get("as_number"):
+                    build_child_xml_node(
+                        self.routing_options,
+                        "autonomous-system",
+                        None,
+                        {"delete": "delete"},
+                    )
+                return bgp_xml
 
         parser = [
             "accept-remote-nexthop",

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
@@ -238,6 +238,11 @@ class Interfaces(ConfigBase):
                 for unit in units:
                     unit_node = build_child_xml_node(intf, "unit")
                     build_child_xml_node(unit_node, "name", str(unit["name"]))
+                    if unit.get("enabled") is not None:
+                        build_child_xml_node(
+                            unit_node,
+                            "enable" if unit["enabled"] else "disable",
+                        )
                     if unit.get("description"):
                         build_child_xml_node(unit_node, "description", unit["description"])
                     if unit.get("vlan_id") is not None:
@@ -361,6 +366,20 @@ class Interfaces(ConfigBase):
                             build_child_xml_node(
                                 unit_node,
                                 "vlan-id",
+                                None,
+                                {"delete": "delete"},
+                            )
+                        if unit.get("enabled") is True:
+                            build_child_xml_node(
+                                unit_node,
+                                "enable",
+                                None,
+                                {"delete": "delete"},
+                            )
+                        if unit.get("enabled") is False:
+                            build_child_xml_node(
+                                unit_node,
+                                "disable",
                                 None,
                                 {"delete": "delete"},
                             )

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/config/interfaces/interfaces.py
@@ -369,6 +369,9 @@ class Interfaces(ConfigBase):
                                 None,
                                 {"delete": "delete"},
                             )
+                        # Unlike the interface-level case (which only removes
+                        # <disable/>), a unit deletes whichever admin-state tag
+                        # it currently carries so both enable and disable clear.
                         if unit.get("enabled") is True:
                             build_child_xml_node(
                                 unit_node,

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/bgp_global/bgp_global.py
@@ -177,7 +177,7 @@ class Bgp_globalFacts(object):
             bgp_group = {}
             groups = bgp.get("group")
             if isinstance(groups, dict):
-                self.parse_attrib(bgp_group, groups)
+                self.parse_attrib(bgp_group, groups, "group")
                 # parse neighbors
                 if "neighbor" in groups.keys():
                     neighbors_lst = []
@@ -209,7 +209,7 @@ class Bgp_globalFacts(object):
             else:
                 for group in groups:
                     bgp_group = {}
-                    self.parse_attrib(bgp_group, group)
+                    self.parse_attrib(bgp_group, group, "group")
                     # Parse neighbors in the group list
                     if "neighbor" in group.keys():
                         neighbors_lst = []
@@ -249,6 +249,9 @@ class Bgp_globalFacts(object):
             if not isinstance(apply_groups, list):
                 apply_groups = [apply_groups]
             cfg_dict["apply_groups"] = apply_groups
+
+        if type in ("group", "neighbor") and conf.get("@inactive") == "inactive":
+            cfg_dict["inactive"] = True
 
         # Read accept-remote-nexthop value
         if "accept-remote-nexthop" in conf.keys():

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/bgp_global/bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/bgp_global/bgp_global.py
@@ -244,6 +244,12 @@ class Bgp_globalFacts(object):
         return bgp_global
 
     def parse_attrib(self, cfg_dict, conf, type=None):
+        if "apply-groups" in conf.keys():
+            apply_groups = conf.get("apply-groups")
+            if not isinstance(apply_groups, list):
+                apply_groups = [apply_groups]
+            cfg_dict["apply_groups"] = apply_groups
+
         # Read accept-remote-nexthop value
         if "accept-remote-nexthop" in conf.keys():
             cfg_dict["accept_remote_nexthop"] = True

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/interfaces/interfaces.py
@@ -164,21 +164,35 @@ class InterfacesFacts(object):
             unit_lst = []
             unit_dict = {}
             if isinstance(units, dict):
-                if "description" in units.keys() or "vlan-id" in units.keys():
+                if any(
+                    key in units.keys()
+                    for key in ("description", "vlan-id", "enable", "disable", "undocumented")
+                ):
                     unit_dict["name"] = units["name"]
                     if "description" in units.keys():
                         unit_dict["description"] = units["description"]
                     if "vlan-id" in units.keys():
                         unit_dict["vlan_id"] = int(units["vlan-id"])
+                    if "enable" in units or "disable" in units:
+                        unit_dict["enabled"] = "enable" in units
+                    if "undocumented" in units:
+                        unit_dict["enabled"] = "enable" in units["undocumented"]
                     unit_lst.append(unit_dict)
             else:
                 for unit in units:
-                    if "description" in unit.keys() or "vlan-id" in unit.keys():
+                    if any(
+                        key in unit.keys()
+                        for key in ("description", "vlan-id", "enable", "disable", "undocumented")
+                    ):
                         unit_dict["name"] = unit["name"]
                         if "description" in unit.keys():
                             unit_dict["description"] = unit["description"]
                         if "vlan-id" in unit.keys():
                             unit_dict["vlan_id"] = int(unit["vlan-id"])
+                        if "enable" in unit or "disable" in unit:
+                            unit_dict["enabled"] = "enable" in unit
+                        if "undocumented" in unit:
+                            unit_dict["enabled"] = "enable" in unit["undocumented"]
                         unit_lst.append(unit_dict)
                         unit_dict = {}
             config["units"] = unit_lst

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/interfaces/interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/interfaces/interfaces.py
@@ -125,6 +125,25 @@ class InterfacesFacts(object):
         )
         return xml_dict
 
+    @staticmethod
+    def _parse_unit(unit):
+        """Extract one logical unit's facts from its xmltodict mapping.
+
+        Returns None for structural-only units (e.g. family-only) that carry
+        none of the resource-module managed keys.
+        """
+        managed_keys = ("description", "vlan-id", "enable", "disable")
+        if not any(key in unit for key in managed_keys):
+            return None
+        unit_dict = {"name": unit["name"]}
+        if "description" in unit:
+            unit_dict["description"] = unit["description"]
+        if "vlan-id" in unit:
+            unit_dict["vlan_id"] = int(unit["vlan-id"])
+        if "enable" in unit or "disable" in unit:
+            unit_dict["enabled"] = "enable" in unit
+        return unit_dict
+
     def render_config(self, spec, conf):
         """
         Render config as dictionary structure and delete keys
@@ -161,40 +180,13 @@ class InterfacesFacts(object):
         unit_cfg = cfg.get("interface")
         if "unit" in unit_cfg.keys():
             units = unit_cfg.get("unit")
-            unit_lst = []
-            unit_dict = {}
             if isinstance(units, dict):
-                if any(
-                    key in units.keys()
-                    for key in ("description", "vlan-id", "enable", "disable", "undocumented")
-                ):
-                    unit_dict["name"] = units["name"]
-                    if "description" in units.keys():
-                        unit_dict["description"] = units["description"]
-                    if "vlan-id" in units.keys():
-                        unit_dict["vlan_id"] = int(units["vlan-id"])
-                    if "enable" in units or "disable" in units:
-                        unit_dict["enabled"] = "enable" in units
-                    if "undocumented" in units:
-                        unit_dict["enabled"] = "enable" in units["undocumented"]
-                    unit_lst.append(unit_dict)
-            else:
-                for unit in units:
-                    if any(
-                        key in unit.keys()
-                        for key in ("description", "vlan-id", "enable", "disable", "undocumented")
-                    ):
-                        unit_dict["name"] = unit["name"]
-                        if "description" in unit.keys():
-                            unit_dict["description"] = unit["description"]
-                        if "vlan-id" in unit.keys():
-                            unit_dict["vlan_id"] = int(unit["vlan-id"])
-                        if "enable" in unit or "disable" in unit:
-                            unit_dict["enabled"] = "enable" in unit
-                        if "undocumented" in unit:
-                            unit_dict["enabled"] = "enable" in unit["undocumented"]
-                        unit_lst.append(unit_dict)
-                        unit_dict = {}
+                units = [units]
+            unit_lst = []
+            for unit in units:
+                parsed_unit = self._parse_unit(unit)
+                if parsed_unit:
+                    unit_lst.append(parsed_unit)
             config["units"] = unit_lst
 
         return utils.remove_empties(config)

--- a/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/module_utils/network/junos/facts/l3_interfaces/l3_interfaces.py
@@ -137,6 +137,15 @@ class L3_interfacesFacts(object):
         interface = {}
         ipv4 = []
         ipv6 = []
+        family = unit.get("family") or {}
+        has_l3_family = isinstance(family, dict) and (
+            "inet" in family or "inet6" in family
+        )
+        # Identity keys must be set for any l3-relevant unit, including
+        # description-only / vlan-id-only units that carry no <family>.
+        if "description" in unit or "vlan-id" in unit or has_l3_family:
+            interface["name"] = int_dict["name"]
+            interface["unit"] = unit["name"]
         if "vlan-tagging" in int_dict:
             interface["vlan_tagging"] = True
         if "description" in unit:
@@ -145,8 +154,6 @@ class L3_interfacesFacts(object):
             interface["vlan_id"] = int(unit["vlan-id"])
         if "family" in unit.keys():
             if "inet" in unit["family"].keys():
-                interface["name"] = int_dict["name"]
-                interface["unit"] = unit["name"]
                 inet = unit["family"].get("inet")
                 if inet is not None and "address" in inet.keys():
                     if isinstance(inet["address"], dict):
@@ -155,8 +162,6 @@ class L3_interfacesFacts(object):
                         for ip in inet["address"]:
                             ipv4.append(self._render_ip_address(ip))
             if "inet" in unit["family"]:
-                interface["name"] = int_dict["name"]
-                interface["unit"] = unit["name"]
                 inet = unit["family"].get("inet")
                 if inet:
                     if inet.get("mtu"):
@@ -166,9 +171,6 @@ class L3_interfacesFacts(object):
                         ipv4.append({"address": "dhcp"})
 
             if "inet6" in unit["family"]:
-                interface["name"] = int_dict["name"]
-                interface["unit"] = unit["name"]
-
                 inet6 = unit["family"].get("inet6")
                 if inet6:
                     if inet6.get("mtu"):

--- a/ansible_collections/juniper/device/plugins/modules/junos_bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_bgp_global.py
@@ -793,6 +793,10 @@ options:
           name:
             description: Specify the name of the group
             type: str
+          apply_groups:
+            description: Inherit configuration from global configuration groups.
+            type: list
+            elements: str
           accept_remote_nexthop: *accept_remote_nexthop
           add_path_display_ipv4_address: *add_path_display_ipv4_address
           advertise_bgp_static: *advertise_bgp_static
@@ -878,6 +882,10 @@ options:
               neighbor_address:
                 description: Specify neighbor address.
                 type: str
+              apply_groups:
+                description: Inherit configuration from global configuration groups.
+                type: list
+                elements: str
               accept_remote_nexthop: *accept_remote_nexthop
               add_path_display_ipv4_address: *add_path_display_ipv4_address
               advertise_bgp_static: *advertise_bgp_static

--- a/ansible_collections/juniper/device/plugins/modules/junos_bgp_global.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_bgp_global.py
@@ -793,6 +793,9 @@ options:
           name:
             description: Specify the name of the group
             type: str
+          inactive: &inactive
+            description: Deactivate this BGP group.
+            type: bool
           apply_groups:
             description: Inherit configuration from global configuration groups.
             type: list
@@ -882,6 +885,7 @@ options:
               neighbor_address:
                 description: Specify neighbor address.
                 type: str
+              inactive: *inactive
               apply_groups:
                 description: Inherit configuration from global configuration groups.
                 type: list

--- a/ansible_collections/juniper/device/plugins/modules/junos_interfaces.py
+++ b/ansible_collections/juniper/device/plugins/modules/junos_interfaces.py
@@ -109,6 +109,9 @@ options:
           description:
             description: Specify logical interface description.
             type: str
+          enabled:
+            description: Administrative state of the logical interface unit.
+            type: bool
           vlan_id:
             description: Specify VLAN ID for the logical interface.
             type: int

--- a/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_interfaces_module.rst
+++ b/ansible_collections/junipernetworks/junos/docs/junipernetworks.junos.junos_interfaces_module.rst
@@ -42,6 +42,23 @@ Parameters
             <tr>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>enabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Administrative state of the logical interface unit.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>config</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/ansible_collections/junipernetworks/junos/tests/unit/mock/procenv.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/mock/procenv.py
@@ -30,7 +30,9 @@ from io import BytesIO, StringIO
 from unittest import TestCase
 
 from ansible.module_utils._text import to_bytes
-from ansible.module_utils.six import PY3
+
+
+PY3 = sys.version_info[0] == 3
 
 
 @contextmanager

--- a/ansible_collections/junipernetworks/junos/tests/unit/mock/yaml_helper.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/mock/yaml_helper.py
@@ -3,12 +3,15 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 import io
+import sys
 
 import yaml
 
-from ansible.module_utils.six import PY3
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.parsing.yaml.loader import AnsibleLoader
+
+
+PY3 = sys.version_info[0] == 3
 
 
 class YamlTestUtils(object):

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/conftest.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/conftest.py
@@ -11,12 +11,11 @@ import pytest
 
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/fixtures/junos_interfaces_unit_enabled_config.xml
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/fixtures/junos_interfaces_unit_enabled_config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply message-id="urn:uuid:0cadb4e8-5bba-47f4-986e-72906227007f">
+    <configuration changed-seconds="1590139550" changed-localtime="2020-05-22 09:25:50 UTC">
+        <interfaces>
+            <interface>
+                <name>ae32</name>
+                <unit>
+                    <name>301</name>
+                    <enable/>
+                </unit>
+                <unit>
+                    <name>302</name>
+                    <disable/>
+                </unit>
+            </interface>
+        </interfaces>
+    </configuration>
+</rpc-reply>

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_bgp_global.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_bgp_global.py
@@ -145,6 +145,30 @@ class TestJunosBgp_globalModule(TestJunosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(result["before"], result["after"])
 
+    def test_junos_bgp_global_deleted_neighbor_only(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    groups=[
+                        dict(
+                            name="ANSIBLE_TEST",
+                            neighbors=[dict(neighbor_address="1.1.1.1")],
+                        ),
+                    ],
+                ),
+                state="deleted",
+            ),
+        )
+        commands = [
+            '<nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            '<nc:bgp><nc:group><nc:name>ANSIBLE_TEST</nc:name>'
+            '<nc:neighbor delete="delete"><nc:name>1.1.1.1</nc:name>'
+            '</nc:neighbor></nc:group></nc:bgp></nc:protocols>',
+            '<nc:routing-options xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>',
+        ]
+        result = self.execute_module(changed=True, commands=commands)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
     def test_junos_bgp_global_replaced(self):
         """
         :return:
@@ -303,6 +327,219 @@ class TestJunosBgp_globalModule(TestJunosModule):
         rendered = ""
         result = self.execute_module(changed=False)
         self.assertEqual(sorted(result["rendered"]), sorted(rendered))
+
+    def test_junos_bgp_global_rendered_neighbor_local_as(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    groups=[
+                        dict(
+                            name="ANSIBLE_TEST",
+                            neighbors=[
+                                dict(
+                                    neighbor_address="1.1.1.1",
+                                    peer_as="65101",
+                                    local_as=dict(
+                                        as_num="12345",
+                                        no_prepend_global_as=True,
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="rendered",
+            ),
+        )
+        rendered = (
+            '<nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:bgp>'
+            "<nc:group><nc:name>ANSIBLE_TEST</nc:name><nc:neighbor><nc:name>1.1.1.1</nc:name>"
+            "<nc:peer-as>65101</nc:peer-as><nc:local-as><nc:as-number>12345</nc:as-number>"
+            "<nc:no-prepend-global-as/></nc:local-as></nc:neighbor></nc:group></nc:bgp></nc:protocols>"
+        )
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["rendered"], rendered)
+
+    def test_junos_bgp_global_rendered_inactive_group_and_neighbor(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    groups=[
+                        dict(
+                            name="ANSIBLE_TEST",
+                            inactive=True,
+                            neighbors=[
+                                dict(
+                                    neighbor_address="1.1.1.1",
+                                    inactive=True,
+                                    peer_as="65101",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="rendered",
+            ),
+        )
+        rendered = (
+            '<nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:bgp>'
+            '<nc:group inactive="inactive"><nc:name>ANSIBLE_TEST</nc:name>'
+            '<nc:neighbor inactive="inactive"><nc:name>1.1.1.1</nc:name>'
+            '<nc:peer-as>65101</nc:peer-as></nc:neighbor></nc:group>'
+            "</nc:bgp></nc:protocols>"
+        )
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["rendered"], rendered)
+
+    def test_junos_bgp_global_rendered_apply_groups(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    groups=[
+                        dict(
+                            name="TEST",
+                            apply_groups=["BGP_GROUP"],
+                            neighbors=[
+                                dict(
+                                    neighbor_address="10.0.0.1",
+                                    apply_groups=["NB_GLOBAL", "BGP_BASIC"],
+                                    peer_as="65101",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="rendered",
+            ),
+        )
+        rendered = (
+            '<nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:bgp>'
+            "<nc:group><nc:name>TEST</nc:name><nc:apply-groups>BGP_GROUP</nc:apply-groups>"
+            "<nc:neighbor><nc:name>10.0.0.1</nc:name>"
+            "<nc:apply-groups>NB_GLOBAL</nc:apply-groups>"
+            "<nc:apply-groups>BGP_BASIC</nc:apply-groups>"
+            "<nc:peer-as>65101</nc:peer-as></nc:neighbor></nc:group>"
+            "</nc:bgp></nc:protocols>"
+        )
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["rendered"], rendered)
+
+    def test_junos_bgp_global_merged_apply_groups(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    groups=[
+                        dict(
+                            name="TEST",
+                            apply_groups=["BGP_GROUP"],
+                            neighbors=[
+                                dict(
+                                    neighbor_address="10.0.0.1",
+                                    apply_groups=["NB_GLOBAL", "BGP_BASIC"],
+                                    peer_as="65101",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="merged",
+            ),
+        )
+        commands = [
+            '<nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:bgp>'
+            "<nc:group><nc:name>TEST</nc:name><nc:apply-groups>BGP_GROUP</nc:apply-groups>"
+            "<nc:neighbor><nc:name>10.0.0.1</nc:name>"
+            "<nc:apply-groups>NB_GLOBAL</nc:apply-groups>"
+            "<nc:apply-groups>BGP_BASIC</nc:apply-groups>"
+            "<nc:peer-as>65101</nc:peer-as></nc:neighbor></nc:group>"
+            "</nc:bgp></nc:protocols>",
+            '<nc:routing-options xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>',
+        ]
+        result = self.execute_module(changed=True, commands=commands)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_junos_bgp_global_deleted_apply_groups(self):
+        set_module_args(
+            dict(
+                config=dict(
+                    groups=[
+                        dict(
+                            name="TEST",
+                            neighbors=[
+                                dict(
+                                    neighbor_address="10.0.0.1",
+                                    apply_groups=["NB_GLOBAL"],
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+                state="deleted",
+            ),
+        )
+        commands = [
+            '<nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:bgp>'
+            "<nc:group><nc:name>TEST</nc:name><nc:neighbor><nc:name>10.0.0.1</nc:name>"
+            '<nc:apply-groups delete="delete">NB_GLOBAL</nc:apply-groups>'
+            "</nc:neighbor></nc:group></nc:bgp></nc:protocols>",
+            '<nc:routing-options xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"/>',
+        ]
+        result = self.execute_module(changed=True, commands=commands)
+        self.assertEqual(sorted(result["commands"]), sorted(commands))
+
+    def test_junos_bgp_global_parsed_apply_groups(self):
+        parsed_str = """
+            <rpc-reply message-id="urn:uuid:0cadb4e8-5bba-47f4-986e-72906227007f">
+                <configuration>
+                    <protocols>
+                        <bgp>
+                            <group>
+                                <name>TEST</name>
+                                <apply-groups>BGP_GROUP</apply-groups>
+                                <neighbor>
+                                    <name>10.0.0.1</name>
+                                    <apply-groups>NB_GLOBAL</apply-groups>
+                                    <apply-groups>BGP_BASIC</apply-groups>
+                                    <peer-as>65101</peer-as>
+                                </neighbor>
+                            </group>
+                        </bgp>
+                    </protocols>
+                </configuration>
+            </rpc-reply>
+        """
+        set_module_args(dict(running_config=parsed_str, state="parsed"))
+        result = self.execute_module(changed=False)
+        group = result["parsed"]["groups"][0]
+        self.assertEqual(group["apply_groups"], ["BGP_GROUP"])
+        self.assertEqual(
+            group["neighbors"][0]["apply_groups"],
+            ["NB_GLOBAL", "BGP_BASIC"],
+        )
+
+    def test_junos_bgp_global_parsed_inactive_group_and_neighbor(self):
+        parsed_str = """
+            <rpc-reply>
+                <configuration>
+                    <protocols>
+                        <bgp>
+                            <group inactive="inactive">
+                                <name>ANSIBLE_TEST</name>
+                                <neighbor inactive="inactive">
+                                    <name>1.1.1.1</name>
+                                    <peer-as>65101</peer-as>
+                                </neighbor>
+                            </group>
+                        </bgp>
+                    </protocols>
+                </configuration>
+            </rpc-reply>
+        """
+        set_module_args(dict(running_config=parsed_str, state="parsed"))
+        result = self.execute_module(changed=False)
+        group = result["parsed"]["groups"][0]
+        self.assertTrue(group["inactive"])
+        self.assertTrue(group["neighbors"][0]["inactive"])
 
     def test_junos_bgp_global_gathered(self):
         """

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
@@ -111,6 +111,29 @@ class TestJunosInterfacesModule(TestJunosModule):
         result = self.execute_module(changed=True)
         self.assertEqual(sorted(result["commands"]), sorted(commands))
 
+    def test_junos_interfaces_logical_unit_enabled_states(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="ae32",
+                        units=[
+                            dict(name=301, enabled=True),
+                            dict(name=302, enabled=False),
+                        ],
+                    ),
+                ],
+                state="rendered",
+            ),
+        )
+        commands = [
+            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            "<nc:interface><nc:name>ae32</nc:name><nc:unit><nc:name>301</nc:name>"
+            "<nc:enable/></nc:unit><nc:unit><nc:name>302</nc:name>"
+            "<nc:disable/></nc:unit></nc:interface></nc:interfaces>",
+        ]
+        self.execute_module(changed=False, commands=commands)
+
     def test_junos_interfaces_merged_idempotent(self):
         self.get_config.return_value = load_fixture(
             "junos_interfaces_config.xml",

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
@@ -186,6 +186,63 @@ class TestJunosInterfacesModule(TestJunosModule):
             ],
         )
 
+    def test_junos_interfaces_unit_enabled_deleted(self):
+        # have (fixture) has unit 301 enabled and unit 302 disabled; deleting the
+        # interface must remove whichever admin-state tag each unit carries.
+        # side_effect wins over load_fixtures' get_config.return_value default.
+        # content="str" keeps the shared load_fixture cache holding a string so
+        # the parsed test (which needs a string running_config) is unaffected.
+        self.get_config.side_effect = lambda *a, **k: load_fixture(
+            "junos_interfaces_unit_enabled_config.xml",
+            content="str",
+        )
+        self.validate_config.side_effect = lambda spec, conf: conf
+        set_module_args(dict(config=[dict(name="ae32")], state="deleted"))
+        result = self.execute_module(changed=True)
+        commands = [
+            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            "<nc:interface><nc:name>ae32</nc:name>"
+            '<nc:unit><nc:name>301</nc:name><nc:enable delete="delete"/></nc:unit>'
+            '<nc:unit><nc:name>302</nc:name><nc:disable delete="delete"/></nc:unit>'
+            "</nc:interface></nc:interfaces>",
+        ]
+        self.assertEqual(result["commands"], commands)
+
+    def test_junos_interfaces_unit_enabled_replaced(self):
+        # have has unit 301 enabled / 302 disabled; want flips them.
+        self.get_config.side_effect = lambda *a, **k: load_fixture(
+            "junos_interfaces_unit_enabled_config.xml",
+            content="str",
+        )
+        self.validate_config.side_effect = lambda spec, conf: conf
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="ae32",
+                        units=[
+                            dict(name=301, enabled=False),
+                            dict(name=302, enabled=True),
+                        ],
+                    ),
+                ],
+                state="replaced",
+            ),
+        )
+        result = self.execute_module(changed=True)
+        commands = [
+            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            "<nc:interface><nc:name>ae32</nc:name>"
+            '<nc:unit><nc:name>301</nc:name><nc:enable delete="delete"/></nc:unit>'
+            '<nc:unit><nc:name>302</nc:name><nc:disable delete="delete"/></nc:unit>'
+            "</nc:interface>"
+            "<nc:interface><nc:name>ae32</nc:name><nc:enable/>"
+            "<nc:unit><nc:name>301</nc:name><nc:disable/></nc:unit>"
+            "<nc:unit><nc:name>302</nc:name><nc:enable/></nc:unit>"
+            "</nc:interface></nc:interfaces>",
+        ]
+        self.assertEqual(result["commands"], commands)
+
     def test_junos_interfaces_merged_idempotent(self):
         self.get_config.return_value = load_fixture(
             "junos_interfaces_config.xml",

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_interfaces.py
@@ -128,11 +128,63 @@ class TestJunosInterfacesModule(TestJunosModule):
         )
         commands = [
             '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
-            "<nc:interface><nc:name>ae32</nc:name><nc:unit><nc:name>301</nc:name>"
+            "<nc:interface><nc:name>ae32</nc:name><nc:enable/><nc:unit><nc:name>301</nc:name>"
             "<nc:enable/></nc:unit><nc:unit><nc:name>302</nc:name>"
             "<nc:disable/></nc:unit></nc:interface></nc:interfaces>",
         ]
-        self.execute_module(changed=False, commands=commands)
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["rendered"], commands[0])
+
+    def test_junos_interfaces_unit_enabled_merged_idempotent(self):
+        set_module_args(
+            dict(
+                config=[
+                    dict(
+                        name="ae32",
+                        units=[
+                            dict(name=301, enabled=True),
+                            dict(name=302, enabled=False),
+                        ],
+                    ),
+                ],
+                state="merged",
+            ),
+        )
+        commands = [
+            '<nc:interfaces xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
+            "<nc:interface><nc:name>ae32</nc:name><nc:enable/>"
+            "<nc:unit><nc:name>301</nc:name><nc:enable/></nc:unit>"
+            "<nc:unit><nc:name>302</nc:name><nc:disable/></nc:unit>"
+            "</nc:interface></nc:interfaces>",
+        ]
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["commands"], commands)
+        self.assertFalse(result["changed"])
+
+    def test_junos_interfaces_unit_enabled_parsed(self):
+        parsed_str = load_fixture(
+            "junos_interfaces_unit_enabled_config.xml",
+            content="str",
+        )
+        set_module_args(dict(running_config=parsed_str, state="parsed"))
+        # validate_config is mocked to a MagicMock in setUp; make it a passthrough
+        # so the facts parser returns the real rendered config for this test.
+        self.validate_config.side_effect = lambda spec, conf: conf
+        result = self.execute_module(changed=False)
+        self.assertEqual(
+            result["parsed"],
+            [
+                {
+                    "name": "ae32",
+                    "enabled": True,
+                    "vlan_tagging": False,
+                    "units": [
+                        {"name": "301", "enabled": True},
+                        {"name": "302", "enabled": False},
+                    ],
+                },
+            ],
+        )
 
     def test_junos_interfaces_merged_idempotent(self):
         self.get_config.return_value = load_fixture(
@@ -273,9 +325,11 @@ class TestJunosInterfacesModule(TestJunosModule):
             "<nc:description>This is configured with ansible resource module</nc:description>"
             "<nc:speed>100m</nc:speed>"
             "<nc:mtu>1024</nc:mtu>"
+            "<nc:enable/>"
             "</nc:interface></nc:interfaces>",
         ]
-        self.execute_module(changed=False, commands=commands)
+        result = self.execute_module(changed=False)
+        self.assertEqual(result["rendered"], commands[0])
 
     def test_junos_interfaces_merged_comment_01(self):
         original_set_module_args = set_module_args

--- a/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l2_interfaces.py
+++ b/ansible_collections/junipernetworks/junos/tests/unit/modules/network/junos/test_junos_l2_interfaces.py
@@ -115,8 +115,6 @@ class TestJunosL2InterfacesModule(TestJunosModule):
         """
         set_module_args(dict(state="gathered"))
         result = self.execute_module(changed=False)
-        with open("gathered_outout.py", "w") as file:
-            file.write(str(result["gathered"]))
         gather_list = [
             {"access": {"vlan": "vlan100"}, "name": "ge-0/0/1", "unit": 0, "enhanced_layer": True},
             {


### PR DESCRIPTION
## Description

Enable & Disable logical interface unit in junos_interface module

Closes #<!-- issue number -->

---

## Collection Namespace

<!-- Identify which collection(s) this PR affects -->

- **Collection namespace:** <!-- e.g. juniper.device -->
- **Collection version (bumped to):** <!-- 2.0.4 -->
- **Module(s) / plugin(s) changed:** <!-- junipernetworks.junos.junos_interface -->

---

## Type of Change

<!-- Check all that apply -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Feature / new module or plugin (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing module or plugin behaviour)
- [ ] Breaking change (fix or feature that would cause existing playbooks / roles to behave differently)
- [ ] Task / Chore (refactor, dependency update, CI, docs, etc.)

---

## Fix Details

Enabled & Disabled logical interface unit in junos_interface module adding enable and disable parameter support

---

## Versions Tested

<!-- Fill in the versions you tested against. Add or remove rows as needed. -->

| Item | Version |
|------|---------|
| Collection namespace & version | juniper.device 2.9.4 |
| Ansible / ansible-core | ansible-core latest |
| Python | 3.13.0 |
| OS | mac |
| Junos version | 26.4 |
| Junos platform | ptx |
| junos-eznc | 2.7.1 |
| ncclient | 0.6.15  |

---

## Sanity Test Results

<!-- Run sanity tests and paste the summary output below. -->

- [X] Sanity tests pass with no new errors

```bash
ansible-test sanity
```

<details>
<summary>Sanity test output</summary>

```
<paste sanity test output here>
```

</details>

---

## Unit Test Results

<!-- Run unit tests and paste the summary output below. -->

- [ ] New or updated unit tests added under `tests/unit/`
- [X] All unit tests pass locally

```bash
python3.12 -m pytest
```

<details>
<summary>Unit test output</summary>

```
<paste unit test output here>
```

</details>

- [ ] Code coverage has not decreased

---

## Integration Test Results

<!-- Run integration tests against a real or virtual Junos device and paste the summary. -->

- [X] Integration tests reviewed for impact
- [ ] Affected integration tests pass (requires a live Junos device or vMX)

```bash
ansible-test network-integration --python 3.12 --inventory /root/pyez_ansible_release_validation1/ansible-junos-stdlib/ansible_collections/juniper/device/tests/integration/inventory.networking
```

<details>
<summary>Integration test output</summary>

```
<paste integration test output here>
```

</details>

---

## Checklist

### Code Quality

- [X] Code follows the project's style guidelines
- [ ] `ansible-lint` passes with no new errors

```bash
ansible-lint
```

- [ ] `flake8` / `ruff` reports no new errors (for Python files)

```bash
flake8 plugins/
# or
ruff check plugins/
```

### Documentation

- [ ] Module documentation (DOCUMENTATION, EXAMPLES, RETURN blocks) updated if parameters changed
- [ ] `CHANGELOG.rst` / `changelogs/fragments/` entry added
- [ ] `galaxy.yml` version bumped if releasing

### General

- [ ] No hardcoded credentials, IP addresses, or sensitive data introduced
- [ ] `requirements.txt` updated if new Python packages are required
- [ ] Backward-compatible: existing playbooks will not break

---

## Additional Notes

<!-- Anything else reviewers should know: deployment considerations, follow-up tasks, known limitations, related PRs, etc. -->
